### PR TITLE
Add dependency check to dashboard script

### DIFF
--- a/scripts/run_dashboard.sh
+++ b/scripts/run_dashboard.sh
@@ -1,3 +1,5 @@
 #!/usr/bin/env bash
 # Launch the FastAPI dashboard with reload enabled.
+python -c "import fastapi, uvicorn" 2>/dev/null \
+  || { echo 'FastAPI and uvicorn are required. Install with pip install -r requirements.txt'; exit 1; }
 uvicorn dashboard.api.main:app --reload


### PR DESCRIPTION
## Summary
- ensure `run_dashboard.sh` checks for FastAPI and uvicorn before launching the server

## Testing
- `bash -n scripts/run_dashboard.sh`
- `./scripts/run_dashboard.sh` (manually started and stopped uvicorn)

------
https://chatgpt.com/codex/tasks/task_e_685345c926008323b68c5d910d470fcf