### PR TITLE
Add color palette configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,7 @@ EcoNexyz is an ecological system of autonomous AI agents that can be registered,
    ```
 
 Visit `http://localhost:8000/status` to see agent status and `http://localhost:8000/messages` for recent bus messages.
+
+## Configuration
+
+The repository includes a color palette definition at `config/color_palette.json`. These values can be consumed by the dashboard or other UI components to ensure a consistent look and feel.

--- a/config/color_palette.json
+++ b/config/color_palette.json
@@ -1,0 +1,5 @@
+{
+  "soft_ecological_greens": ["#3DA35D", "#7ABF8C"],
+  "tech_contrast_blues_teals": ["#2C97DE", "#4AC2E0", "#65A3D9"],
+  "neutral_base_slate_stone": ["#5C6469", "#DCE0E2"]
+}


### PR DESCRIPTION
## Summary
- define a reusable color palette in a new `config/color_palette.json`
- mention this palette in the README for reference

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68534321984883238a0561c44940c226