### PR TITLE
Implement weather agent, basic dashboard, and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,4 @@ cython_debug/
 .cursorindexingignore
 knowledge.db
 .DS_Store
+logs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ agent.run()
 
 ## 📌 Example Agent
 
-For a practical reference, review [`agents/sample_agent.py`](agents/sample_agent.py).
+For practical references, review [`agents/sample.py`](econexyz/agents/sample.py) and [`agents/weather.py`](econexyz/agents/weather.py).
 
 ---
 
@@ -115,3 +115,5 @@ For a practical reference, review [`agents/sample_agent.py`](agents/sample_agent
 ## 🚀 Ready to create your agent?
 
 Follow this guide, keep your implementations clean, and have fun building intelligent, autonomous behavior into the **EcoNexyz** ecosystem!
+
+Additional project-wide tasks are tracked in [TODO.md](TODO.md).

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ EcoNexyz is an ecological system of autonomous AI agents that can be registered,
 
 ## Repository Structure
 
-- `econexyz/` – core Python modules for agents, message bus, and storage.
+- `econexyz/` – core Python modules for agents (including a sample and weather agent), message bus, and storage.
 - `dashboard/api/` – FastAPI server exposing simple monitoring endpoints.
-- `dashboard/web/` – placeholder for a future React dashboard.
+- `dashboard/web/` – minimal React dashboard displaying status and messages.
 - `scripts/` – helper scripts to run agents and the dashboard.
 
 ## Quick Start
@@ -39,17 +39,24 @@ EcoNexyz is an ecological system of autonomous AI agents that can be registered,
    ```bash
    pip install -r requirements.txt
    ```
-2. Run the sample agent:
+2. Run the sample agent (or experiment with the weather agent by editing `scripts/run_agents.py`):
    ```bash
    python scripts/run_agents.py
    ```
-3. Start the dashboard API:
+3. Start the dashboard API and web UI:
    ```bash
    ./scripts/run_dashboard.sh
    ```
+   Then open `dashboard/web/index.html` in your browser.
 
 Visit `http://localhost:8000/` for instructions, `http://localhost:8000/status` to see agent status and `http://localhost:8000/messages` for recent bus messages.
 
 ## Configuration
 
-The repository includes a color palette definition at `config/color_palette.json`. These values can be consumed by the dashboard or other UI components to ensure a consistent look and feel.
+The repository includes a color palette definition at `config/color_palette.json`. These values are used by the dashboard for consistent styling.
+
+Runtime logs are written to `~/tmp/econexyz.log` and are ignored by git.
+
+## Project TODOs
+
+Ongoing development tasks are tracked in [TODO.md](TODO.md). Contributions and ideas are welcome!

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,8 @@
+# TODO
+
+- [ ] Implement more robust dashboard frontend using React.
+- [ ] Integrate color palette from `config/color_palette.json` into dashboard styling.
+- [ ] Write integration tests for message bus and knowledge store.
+- [ ] Enhance sample agent and add new agents, such as one that retrieves local weather.
+- [ ] Improve error handling and logging; store logs under `~/tmp` or another ignored path.
+- [ ] Provide script or CLI options to launch multiple agents simultaneously.

--- a/dashboard/web/README.md
+++ b/dashboard/web/README.md
@@ -1,3 +1,5 @@
 # Dashboard Web
 
-Placeholder for future React frontend.
+This directory contains a very small React-based dashboard. Open `index.html` in a browser while the FastAPI server is running to see agent status and recent messages.
+
+The color palette defined in `../../config/color_palette.json` is applied via CSS variables for a consistent look.

--- a/dashboard/web/app.js
+++ b/dashboard/web/app.js
@@ -1,0 +1,25 @@
+const e = React.createElement;
+
+function useFetch(url) {
+  const [data, setData] = React.useState(null);
+  React.useEffect(() => {
+    const fetchData = () => fetch(url).then(r => r.json()).then(setData).catch(() => {});
+    fetchData();
+    const id = setInterval(fetchData, 2000);
+    return () => clearInterval(id);
+  }, [url]);
+  return data;
+}
+
+function Dashboard() {
+  const status = useFetch('/status');
+  const messages = useFetch('/messages');
+  return e('div', null,
+    e('h2', null, 'Agents'),
+    e('pre', null, JSON.stringify(status, null, 2)),
+    e('h2', null, 'Messages'),
+    e('pre', null, JSON.stringify(messages, null, 2))
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(e(Dashboard));

--- a/dashboard/web/index.html
+++ b/dashboard/web/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8" />
+  <title>EcoNexyz Dashboard</title>
+  <style>
+    :root {
+      --green: #3DA35D;
+      --blue: #2C97DE;
+      --slate: #5C6469;
+      --background: #DCE0E2;
+    }
+    body {
+      font-family: sans-serif;
+      background: var(--background);
+      margin: 0;
+      padding: 1rem;
+    }
+    h1 { color: var(--green); }
+    pre {
+      background: #fff;
+      padding: 1em;
+      border: 1px solid var(--slate);
+    }
+  </style>
+</head>
+<body>
+  <h1>EcoNexyz Dashboard</h1>
+  <div id="root"></div>
+  <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/econexyz/agents/__init__.py
+++ b/econexyz/agents/__init__.py
@@ -1,0 +1,6 @@
+"""Agent package exports."""
+
+from .sample import SampleAgent
+from .weather import WeatherAgent
+
+__all__ = ["SampleAgent", "WeatherAgent"]

--- a/econexyz/agents/sample.py
+++ b/econexyz/agents/sample.py
@@ -2,6 +2,7 @@
 
 import time
 from threading import Event
+import logging
 
 from .base import Agent
 
@@ -20,6 +21,7 @@ class SampleAgent(Agent):
         while self.running and not self._stop_event.is_set():
             message = {"agent": self.name, "counter": counter}
             self.bus.publish("sample", message)
+            logging.info("%s published %s", self.name, message)
             counter += 1
             time.sleep(self.interval)
 

--- a/econexyz/agents/weather.py
+++ b/econexyz/agents/weather.py
@@ -1,0 +1,45 @@
+"""Agent that periodically publishes local weather information."""
+
+import time
+from threading import Event
+from typing import Optional
+import logging
+
+import requests
+
+from .base import Agent
+
+
+class WeatherAgent(Agent):
+    """Fetches weather data from wttr.in and publishes it."""
+
+    def __init__(self, name: str, bus, store, location: str = "", interval: float = 600.0):
+        super().__init__(name, bus, store)
+        self.location = location
+        self.interval = interval
+        self._stop_event = Event()
+
+    def _get_weather(self) -> Optional[str]:
+        try:
+            url = f"https://wttr.in/{self.location}?format=3"
+            resp = requests.get(url, timeout=10)
+            if resp.status_code == 200:
+                return resp.text.strip()
+            logging.error("Weather request failed: %s", resp.status_code)
+        except Exception as exc:  # pylint: disable=broad-except
+            logging.exception("Error fetching weather: %s", exc)
+        return None
+
+    def run(self) -> None:
+        """Periodically fetch and publish weather info."""
+        while self.running and not self._stop_event.is_set():
+            weather = self._get_weather()
+            if weather:
+                message = {"agent": self.name, "weather": weather}
+                self.bus.publish("weather", message)
+                logging.info("Published weather: %s", weather)
+            time.sleep(self.interval)
+
+    def shutdown(self) -> None:
+        super().shutdown()
+        self._stop_event.set()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+requests
+pytest

--- a/scripts/run_agents.py
+++ b/scripts/run_agents.py
@@ -4,6 +4,8 @@ import threading
 import time
 from pathlib import Path
 import sys
+import os
+import logging
 
 # Allow running without installation
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -15,6 +17,14 @@ from dashboard.api import state
 
 
 def main() -> None:
+    log_dir = os.path.expanduser("~/tmp")
+    os.makedirs(log_dir, exist_ok=True)
+    logging.basicConfig(
+        filename=os.path.join(log_dir, "econexyz.log"),
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+    )
+
     bus = InMemoryMessageBus()
     with SQLiteKnowledgeStore() as store:
         agent = SampleAgent("sample-agent", bus, store)

--- a/tests/test_message_bus.py
+++ b/tests/test_message_bus.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from econexyz.message_bus.in_memory import InMemoryMessageBus
+
+def test_publish_subscribe(tmp_path):
+    bus = InMemoryMessageBus()
+    received = []
+
+    def handler(msg):
+        received.append(msg)
+
+    bus.subscribe("test", handler)
+    bus.publish("test", {"foo": "bar"})
+
+    assert received == [{"foo": "bar"}]
+    messages = bus.get_messages()
+    assert messages[0]["message"] == {"foo": "bar"}

--- a/tests/test_sqlite_store.py
+++ b/tests/test_sqlite_store.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from econexyz.storage.sqlite_store import SQLiteKnowledgeStore
+
+
+def test_save_load(tmp_path):
+    db_path = tmp_path / "test.db"
+    store = SQLiteKnowledgeStore(str(db_path))
+    store.save("key", {"value": 1})
+    result = store.load("key")
+    assert result == {"value": 1}
+    store.close()


### PR DESCRIPTION
## Summary
- add TODO list for project planning
- implement minimal React dashboard utilizing the color palette
- create WeatherAgent and export via agents package
- log agent actions to `~/tmp/econexyz.log`
- ignore log directory in git
- update docs and development guide
- include integration tests for message bus and SQLite store

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68534b21b2d083238e265e59350f6111