### PR TITLE
Add logging hooks for agent runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Visit `http://localhost:8000/` for instructions, `http://localhost:8000/status` 
 
 The repository includes a color palette definition at `config/color_palette.json`. These values are used by the dashboard for consistent styling.
 
-Runtime logs are written to `~/tmp/econexyz.log` and are ignored by git.
+Runtime logs are written to `~/tmp/econexyz.log` and are ignored by git. Agents log setup, shutdown, and message publishing events to help verify they are running correctly.
 
 ## Project TODOs
 

--- a/econexyz/agents/base.py
+++ b/econexyz/agents/base.py
@@ -1,6 +1,7 @@
 """Agent base class defining lifecycle methods."""
 
 from abc import ABC, abstractmethod
+import logging
 
 from econexyz.message_bus.base import MessageBus
 from econexyz.storage.base import KnowledgeStore
@@ -18,6 +19,7 @@ class Agent(ABC):
     def setup(self) -> None:
         """Initialize resources before running."""
         self.running = True
+        logging.info("Agent %s setup", self.name)
 
     @abstractmethod
     def run(self) -> None:
@@ -27,3 +29,4 @@ class Agent(ABC):
     def shutdown(self) -> None:
         """Clean up resources when the agent stops."""
         self.running = False
+        logging.info("Agent %s shutting down", self.name)

--- a/econexyz/agents/sample.py
+++ b/econexyz/agents/sample.py
@@ -17,6 +17,7 @@ class SampleAgent(Agent):
 
     def run(self) -> None:
         """Run a simple loop publishing incrementing counters."""
+        logging.info("%s started", self.name)
         counter = 0
         while self.running and not self._stop_event.is_set():
             message = {"agent": self.name, "counter": counter}

--- a/econexyz/agents/weather.py
+++ b/econexyz/agents/weather.py
@@ -32,6 +32,7 @@ class WeatherAgent(Agent):
 
     def run(self) -> None:
         """Periodically fetch and publish weather info."""
+        logging.info("%s started", self.name)
         while self.running and not self._stop_event.is_set():
             weather = self._get_weather()
             if weather:

--- a/econexyz/message_bus/in_memory.py
+++ b/econexyz/message_bus/in_memory.py
@@ -2,6 +2,7 @@
 
 import threading
 import time
+import logging
 from collections import defaultdict
 from typing import Callable, Dict, Any, List
 
@@ -17,12 +18,14 @@ class InMemoryMessageBus(MessageBus):
         self._lock = threading.Lock()
 
     def publish(self, topic: str, message: Dict[str, Any]) -> None:
+        logging.info("Publishing to %s: %s", topic, message)
         with self._lock:
             self.messages.append({"topic": topic, "message": message, "ts": time.time()})
         for callback in list(self.subscribers.get(topic, [])):
             callback(message)
 
     def subscribe(self, topic: str, callback: Callable[[Dict[str, Any]], None]) -> None:
+        logging.info("Subscribed callback to topic %s", topic)
         self.subscribers[topic].append(callback)
 
     def get_messages(self) -> List[Dict[str, Any]]:


### PR DESCRIPTION
## Summary
- emit setup and shutdown logs from Agent base class
- log start of run loop in sample and weather agents
- trace publish and subscribe actions in the in-memory message bus
- mention logging behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68537537a03483238363ac7d42e0b93c