### PR TITLE
Generate palette CSS from JSON

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,6 +7,7 @@ PYTHON_BIN="python3"
 VENV_DIR=".venv"
 REQUIREMENTS="requirements.txt"
 AGENT_SCRIPT="scripts/run_agents.py"
+PALETTE_SCRIPT="scripts/generate_palette_css.py"
 
 # Function to print errors and exit
 error_exit() {
@@ -27,6 +28,11 @@ if [ ! -f "$AGENT_SCRIPT" ]; then
   error_exit "Could not find $AGENT_SCRIPT. Are you in the project root?"
 fi
 
+# Ensure palette generation script exists
+if [ ! -f "$PALETTE_SCRIPT" ]; then
+  error_exit "Could not find $PALETTE_SCRIPT."
+fi
+
 # Create venv if needed
 if [ ! -d "$VENV_DIR" ]; then
   echo "[INFO] Creating virtual environment in $VENV_DIR..."
@@ -41,6 +47,9 @@ echo "[INFO] Virtual environment activated."
 pip install --upgrade pip || error_exit "Failed to upgrade pip."
 pip install -r $REQUIREMENTS || error_exit "Failed to install requirements."
 echo "[INFO] Requirements installed."
+
+# Generate dashboard color palette CSS
+python "$PALETTE_SCRIPT" || error_exit "Failed to run $PALETTE_SCRIPT"
 
 echo "[INFO] Starting agents..."
 python $AGENT_SCRIPT || error_exit "Failed to run $AGENT_SCRIPT." 

--- a/dashboard/web/README.md
+++ b/dashboard/web/README.md
@@ -3,3 +3,11 @@
 This directory contains a very small React-based dashboard. Open `index.html` in a browser while the FastAPI server is running to see agent status and recent messages.
 
 The color palette defined in `../../config/color_palette.json` is applied via CSS variables for a consistent look.
+
+The palette CSS is generated automatically when you run `bootstrap.sh`, but you can also generate it manually if needed:
+
+```bash
+python ../../scripts/generate_palette_css.py
+```
+
+This writes `palette.css` which `index.html` loads for its color variables.

--- a/dashboard/web/index.html
+++ b/dashboard/web/index.html
@@ -3,13 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <title>EcoNexyz Dashboard</title>
+  <link rel="stylesheet" href="palette.css" />
   <style>
-    :root {
-      --green: #3DA35D;
-      --blue: #2C97DE;
-      --slate: #5C6469;
-      --background: #DCE0E2;
-    }
     body {
       font-family: sans-serif;
       background: var(--background);

--- a/dashboard/web/palette.css
+++ b/dashboard/web/palette.css
@@ -1,0 +1,14 @@
+:root {
+  /* Generated from config/color_palette.json */
+  --soft-ecological-greens-1: #3DA35D;
+  --soft-ecological-greens-2: #7ABF8C;
+  --tech-contrast-blues-teals-1: #2C97DE;
+  --tech-contrast-blues-teals-2: #4AC2E0;
+  --tech-contrast-blues-teals-3: #65A3D9;
+  --neutral-base-slate-stone-1: #5C6469;
+  --neutral-base-slate-stone-2: #DCE0E2;
+  --green: #3DA35D;
+  --blue: #2C97DE;
+  --slate: #5C6469;
+  --background: #DCE0E2;
+}

--- a/scripts/generate_palette_css.py
+++ b/scripts/generate_palette_css.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Generate CSS variables from config/color_palette.json."""
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFIG = ROOT / "config" / "color_palette.json"
+OUTPUT = ROOT / "dashboard" / "web" / "palette.css"
+
+
+def main() -> None:
+    with open(CONFIG) as f:
+        palette = json.load(f)
+
+    lines = [":root {", "  /* Generated from config/color_palette.json */"]
+    for group, colors in palette.items():
+        base = group.replace("_", "-")
+        for idx, color in enumerate(colors, 1):
+            lines.append(f"  --{base}-{idx}: {color};")
+
+    # Compatibility variables used in index.html
+    try:
+        lines.append(f"  --green: {palette['soft_ecological_greens'][0]};")
+    except (KeyError, IndexError):
+        pass
+    try:
+        lines.append(f"  --blue: {palette['tech_contrast_blues_teals'][0]};")
+    except (KeyError, IndexError):
+        pass
+    try:
+        lines.append(f"  --slate: {palette['neutral_base_slate_stone'][0]};")
+    except (KeyError, IndexError):
+        pass
+    try:
+        lines.append(f"  --background: {palette['neutral_base_slate_stone'][1]};")
+    except (KeyError, IndexError):
+        pass
+
+    lines.append("}")
+    OUTPUT.write_text("\n".join(lines) + "\n")
+    print(f"Wrote {OUTPUT.relative_to(ROOT)}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- generate CSS variables from `config/color_palette.json`
- include generated `palette.css` in the dashboard
- document palette CSS build step
- automate palette generation in `bootstrap.sh`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68537d2d74a0832398870b487d1b8036