### PR TITLE
Organize TODOs with local issue files

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,16 +1,22 @@
 # TODO
 
-- [ ] Implement more robust dashboard frontend using React.
-- [ ] Integrate color palette from `config/color_palette.json` into dashboard styling.
-- [ ] Write integration tests for message bus and knowledge store.
-- [ ] Enhance sample agent and add new agents, such as one that retrieves local weather.
-- [ ] Improve error handling and logging; store logs under `~/tmp` or another ignored path.
-- [ ] Provide script or CLI options to launch multiple agents simultaneously.
+This repository tracks work items in the `issues/` directory. Each task below links to a markdown file that contains additional details.
 
-## Event Bus Enhancements
+## Dashboard
+- [ ] [dashboard/frontend_react](issues/dashboard/frontend_react.md) - Implement a React-based dashboard frontend.
+- [ ] [dashboard/color_palette](issues/dashboard/color_palette.md) - Apply the shared color palette to dashboard styling.
 
-- [ ] Add pagination to the `/messages` endpoint, returning the most recent events capped at 50.
-- [ ] Implement optional message TTL to prevent unbounded growth of stored events.
-- [ ] Provide an optional queue implementation for polling messages with removal semantics.
-- [ ] Support a production-ready bus/queue backend (e.g., Redis or NATS) in place of the in-memory bus.
-- [ ] Refactor agent runner and dashboard to inject the chosen bus or queue implementation.
+## Agents
+- [ ] [agents/enhance_sample_agent](issues/agents/enhance_sample_agent.md) - Improve the sample agent and create new agents (e.g., weather).
+- [ ] [agents/multi_agent_cli](issues/agents/multi_agent_cli.md) - Provide CLI options to run multiple agents.
+
+## Cross-cutting
+- [ ] [cross/integration_tests](issues/cross/integration_tests.md) - Write integration tests for the message bus and knowledge store.
+- [ ] [cross/logging_improvements](issues/cross/logging_improvements.md) - Enhance error handling and logging.
+
+## Event Bus
+- [ ] [bus/message_pagination](issues/bus/message_pagination.md) - Add pagination to the `/messages` endpoint.
+- [ ] [bus/message_ttl](issues/bus/message_ttl.md) - Implement optional message TTL.
+- [ ] [bus/queue_polling](issues/bus/queue_polling.md) - Provide a queue with polling and removal semantics.
+- [ ] [bus/prod_backend](issues/bus/prod_backend.md) - Support a production-ready backend such as Redis or NATS.
+- [ ] [bus/inject_bus_impl](issues/bus/inject_bus_impl.md) - Inject the chosen bus implementation into the agent runner and dashboard.

--- a/issues/agents/enhance_sample_agent.md
+++ b/issues/agents/enhance_sample_agent.md
@@ -1,0 +1,3 @@
+# agents/enhance_sample_agent
+
+Enhance the existing sample agent and create additional agents, such as one that retrieves local weather information.

--- a/issues/agents/multi_agent_cli.md
+++ b/issues/agents/multi_agent_cli.md
@@ -1,0 +1,3 @@
+# agents/multi_agent_cli
+
+Provide a script or CLI options to launch multiple agents simultaneously for easier demos and testing.

--- a/issues/bus/inject_bus_impl.md
+++ b/issues/bus/inject_bus_impl.md
@@ -1,0 +1,3 @@
+# bus/inject_bus_impl
+
+Refactor the agent runner and dashboard to inject the chosen message bus or queue implementation at runtime.

--- a/issues/bus/message_pagination.md
+++ b/issues/bus/message_pagination.md
@@ -1,0 +1,3 @@
+# bus/message_pagination
+
+Add pagination to the `/messages` endpoint. Return the most recent events with a default cap of 50 per page.

--- a/issues/bus/message_ttl.md
+++ b/issues/bus/message_ttl.md
@@ -1,0 +1,3 @@
+# bus/message_ttl
+
+Implement an optional time-to-live (TTL) for messages so old events are purged automatically.

--- a/issues/bus/prod_backend.md
+++ b/issues/bus/prod_backend.md
@@ -1,0 +1,3 @@
+# bus/prod_backend
+
+Support a production-ready bus or queue backend (e.g., Redis or NATS) instead of the in-memory bus.

--- a/issues/bus/queue_polling.md
+++ b/issues/bus/queue_polling.md
@@ -1,0 +1,3 @@
+# bus/queue_polling
+
+Provide an optional queue implementation that allows polling for messages with removal semantics.

--- a/issues/cross/integration_tests.md
+++ b/issues/cross/integration_tests.md
@@ -1,0 +1,3 @@
+# cross/integration_tests
+
+Add integration tests covering interactions between the message bus and knowledge store to catch regressions across modules.

--- a/issues/cross/logging_improvements.md
+++ b/issues/cross/logging_improvements.md
@@ -1,0 +1,3 @@
+# cross/logging_improvements
+
+Improve error handling and logging across the project. Logs should be written under `~/tmp` or another path ignored by git.

--- a/issues/dashboard/color_palette.md
+++ b/issues/dashboard/color_palette.md
@@ -1,0 +1,3 @@
+# dashboard/color_palette
+
+Use the color palette defined in `config/color_palette.json` to style the dashboard consistently. All pages and components should reference these values.

--- a/issues/dashboard/frontend_react.md
+++ b/issues/dashboard/frontend_react.md
@@ -1,0 +1,3 @@
+# dashboard/frontend_react
+
+Implement a React-based frontend for the dashboard. Replace the current static HTML with components that display agent status, messages, and logs. Styling should use the shared color palette.


### PR DESCRIPTION
## Summary
- add `issues/` directory with categorized issue files
- rewrite `TODO.md` to reference issue files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68538102568c83239545c18e80644d49