### PR TITLE
Implement message pagination

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -15,7 +15,7 @@ This repository tracks work items in the `issues/` directory. Each task below li
 - [ ] [cross/logging_improvements](issues/cross/logging_improvements.md) - Enhance error handling and logging.
 
 ## Event Bus
-- [ ] [bus/message_pagination](issues/bus/message_pagination.md) - Add pagination to the `/messages` endpoint.
+- [x] [bus/message_pagination](issues/bus/message_pagination.md) - Add pagination to the `/messages` endpoint.
 - [ ] [bus/message_ttl](issues/bus/message_ttl.md) - Implement optional message TTL.
 - [ ] [bus/queue_polling](issues/bus/queue_polling.md) - Provide a queue with polling and removal semantics.
 - [ ] [bus/prod_backend](issues/bus/prod_backend.md) - Support a production-ready backend such as Redis or NATS.

--- a/dashboard/api/main.py
+++ b/dashboard/api/main.py
@@ -24,9 +24,17 @@ def get_status():
 
 
 @app.get("/messages")
-def get_messages():
-    """Return recently published messages."""
+def get_messages(page: int = 1, page_size: int = 50):
+    """Return recently published messages with pagination."""
     bus = state.message_bus
     if bus and hasattr(bus, "get_messages"):
-        return {"messages": bus.get_messages()}
+        messages = list(reversed(bus.get_messages()))
+        start = max(page - 1, 0) * page_size
+        end = start + page_size
+        return {
+            "page": page,
+            "page_size": page_size,
+            "total": len(messages),
+            "messages": messages[start:end],
+        }
     return {"messages": []}

--- a/issues/bus/message_pagination.md
+++ b/issues/bus/message_pagination.md
@@ -1,3 +1,5 @@
 # bus/message_pagination
 
 Add pagination to the `/messages` endpoint. Return the most recent events with a default cap of 50 per page.
+
+Status: Completed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi
 uvicorn
 requests
+httpx
 pytest

--- a/tests/test_api_pagination.py
+++ b/tests/test_api_pagination.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+if 'requests' not in sys.modules:
+    sys.modules['requests'] = type('Dummy', (), {})()
+
+from dashboard.api.main import get_messages
+from dashboard.api import state
+from econexyz.message_bus.in_memory import InMemoryMessageBus
+
+
+def test_messages_pagination():
+    bus = InMemoryMessageBus()
+    state.message_bus = bus
+    for i in range(60):
+        bus.publish("test", {"num": i})
+
+    data = get_messages()
+    assert data["page"] == 1
+    assert data["page_size"] == 50
+    assert data["total"] == 60
+    assert len(data["messages"]) == 50
+    assert data["messages"][0]["message"]["num"] == 59
+    assert data["messages"][-1]["message"]["num"] == 10
+
+    data = get_messages(page=2)
+    assert data["page"] == 2
+    assert len(data["messages"]) == 10
+    assert data["messages"][0]["message"]["num"] == 9
+    assert data["messages"][-1]["message"]["num"] == 0
+
+    state.message_bus = None


### PR DESCRIPTION
## Summary
- add pagination to dashboard API's `/messages` endpoint
- update dependencies
- test new pagination logic
- mark message pagination TODO and issue complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853827d3e4c8323896414c2b6397a89