### PR TITLE
Implement sprint file validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,12 @@ python scripts/ai_helper.py
 
 This outputs the current sprint plan as JSON.
 
+You can also normalize sprint files with:
+
+```bash
+python scripts/ai_helper.py --fix
+```
+
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -87,3 +87,9 @@ To view the sprint plan in JSON form for AI tools, run:
 ```bash
 python scripts/ai_helper.py
 ```
+
+To normalize sprint files and fix minor formatting issues, pass `--fix`:
+
+```bash
+python scripts/ai_helper.py --fix
+```

--- a/TODO.md
+++ b/TODO.md
@@ -30,4 +30,4 @@ This repository tracks work items in the `issues/` directory. Each task below li
 - [x] [workflow/implement-integrated-sprint-and-issue-workflow](issues/closed/workflow/implement-integrated-sprint-and-issue-workflow.md) - Implement integrated sprint and issue workflow with archival structure.
   - [x] Update Documentation & Agent Instructions (PR #3)
   - [x] Optional - AI Integration Helper (PR #4)
-- [ ] [workflow/sprint-file-validation](issues/open/workflow/sprint-file-validation.md) - Validate sprint files and warn on formatting errors.
+- [x] [workflow/sprint-file-validation](issues/closed/workflow/sprint-file-validation.md) - Validate sprint files and warn on formatting errors.

--- a/issues/closed/workflow/sprint-file-validation.md
+++ b/issues/closed/workflow/sprint-file-validation.md
@@ -3,5 +3,5 @@
 Add validation and warnings for sprint markdown files to improve JSON output.
 
 ## Tasks
-- Warn on unrecognized issue lines
-- Optional: provide command to fix formatting
+- [x] Warn on unrecognized issue lines
+- [x] Optional: provide command to fix formatting

--- a/scripts/ai_helper.py
+++ b/scripts/ai_helper.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Output current sprint plans as JSON for AI tools."""
 
+import argparse
 import json
 import logging
 import re
@@ -14,34 +15,92 @@ SPRINT_DIR = ROOT / "sprints" / "current"
 # - [ ] [category/name](../path/to/issue.md)
 # capturing the closed marker, title, and relative path.
 ISSUE_PATTERN = re.compile(r"- \[( |x)\] \[([^\]]+)\]\(([^)]+)\)")
+LOOSE_PATTERN = re.compile(r"-\s*\[( |x)\]\s*\[([^\]]+)\]\(([^)]+)\)")
 
 
-def parse_sprint(path: Path) -> dict:
+def _format_issue(closed: bool, title: str, path: str) -> str:
+    """Return a normalized checklist line for an issue."""
+
+    mark = "x" if closed else " "
+    return f"- [{mark}] [{title}]({path})"
+
+
+def parse_sprint(path: Path, *, fix: bool = False) -> dict:
     """Return sprint metadata and issue list from a markdown file."""
 
     issues = []
-    for line in path.read_text().splitlines():
+    lines = path.read_text().splitlines()
+    new_lines = []
+    changed = False
+
+    for idx, line in enumerate(lines, 1):
         m = ISSUE_PATTERN.search(line)
         if m:
             closed = m.group(1) == "x"
-            issues.append({
-                "title": m.group(2),
-                "path": m.group(3),
-                "closed": closed,
-            })
-        elif line.strip().startswith("- ["):
-            # TODO: Add dedicated validation of sprint files
-            logging.warning("unrecognized issue format: %s", line.strip())
+            title = m.group(2)
+            rel_path = m.group(3)
+            issues.append({"title": title, "path": rel_path, "closed": closed})
+            formatted = _format_issue(closed, title, rel_path)
+            if fix:
+                new_lines.append(formatted)
+                if line != formatted:
+                    changed = True
+            else:
+                new_lines.append(line)
+            continue
+
+        if line.strip().startswith("- ["):
+            lm = LOOSE_PATTERN.search(line)
+            if lm:
+                closed = lm.group(1) == "x"
+                title = lm.group(2)
+                rel_path = lm.group(3)
+                issues.append({"title": title, "path": rel_path, "closed": closed})
+                formatted = _format_issue(closed, title, rel_path)
+                if fix:
+                    new_lines.append(formatted)
+                    if line != formatted:
+                        changed = True
+                else:
+                    logging.warning(
+                        "nonstandard issue format in %s:%d: %s",
+                        path.name,
+                        idx,
+                        line.strip(),
+                    )
+                    new_lines.append(line)
+                continue
+
+            logging.warning(
+                "unrecognized issue format in %s:%d: %s",
+                path.name,
+                idx,
+                line.strip(),
+            )
+            new_lines.append(line)
+        else:
+            new_lines.append(line)
+
+    if fix and changed:
+        path.write_text("\n".join(new_lines) + "\n")
 
     return {"name": path.stem, "issues": issues}
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="Sprint helper")
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="rewrite sprint files with normalized issue lines",
+    )
+    args = parser.parse_args()
+
     logging.basicConfig(level=logging.INFO)
     plans = []
     if SPRINT_DIR.is_dir():
         for f in sorted(SPRINT_DIR.glob("*.md")):
-            plans.append(parse_sprint(f))
+            plans.append(parse_sprint(f, fix=args.fix))
     print(json.dumps({"sprints": plans}, indent=2))
 
 

--- a/tests/test_ai_helper.py
+++ b/tests/test_ai_helper.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts.ai_helper import parse_sprint, _format_issue
+
+
+def test_parse_and_fix(tmp_path):
+    sprint = tmp_path / "sprint.md"
+    sprint.write_text(
+        "# Sprint\n\n## Issues\n- [ ] [cat/foo](../issues/open/cat/foo.md)\n- [x][cat/bar](../issues/closed/cat/bar.md) \n- [ ] bad line\n"
+    )
+    plan = parse_sprint(sprint)
+    assert plan["name"] == "sprint"
+    # Nonstandard line still parsed but triggers warning
+    assert len(plan["issues"]) == 2
+
+    parse_sprint(sprint, fix=True)
+    plan = parse_sprint(sprint)
+    lines = sprint.read_text().splitlines()
+    assert len(plan["issues"]) == 2
+    assert lines[3] == _format_issue(False, "cat/foo", "../issues/open/cat/foo.md")
+    assert lines[4] == _format_issue(True, "cat/bar", "../issues/closed/cat/bar.md")
+


### PR DESCRIPTION
## Summary
- add validation and fixer to `scripts/ai_helper.py`
- document `--fix` option in README and AGENTS instructions
- close workflow/sprint-file-validation issue
- add tests for the new functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68539b5e8b8c8323ba4730c7695691d8