### PR TITLE
Add workflow backlog tasks

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,7 @@ This repository tracks work items in the `issues/` directory. Each task below li
 ## Dashboard
 - [ ] [dashboard/frontend_react](issues/open/dashboard/frontend_react.md) - Implement a React-based dashboard frontend.
 - [ ] [dashboard/color_palette](issues/open/dashboard/color_palette.md) - Apply the shared color palette to dashboard styling.
+- [ ] [dashboard/view_tasks_and_sprint](issues/open/dashboard/view_tasks_and_sprint.md) - Show tasks and sprint in the dashboard.
 
 ## Agents
 - [ ] [agents/enhance_sample_agent](issues/open/agents/enhance_sample_agent.md) - Improve the sample agent and create new agents (e.g., weather).
@@ -32,3 +33,10 @@ This repository tracks work items in the `issues/` directory. Each task below li
   - [x] Optional - AI Integration Helper (PR #4)
 - [x] [workflow/sprint-file-validation](issues/closed/workflow/sprint-file-validation.md) - Validate sprint files and warn on formatting errors.
 - [x] [workflow/implement-git-transactions](issues/closed/workflow/implement-git-transactions.md) - Implement transactional Git workflow scripts and documentation
+- [ ] [workflow/run_sprint_planning](issues/open/workflow/run_sprint_planning.md) - Run a sprint planning workflow.
+- [ ] [workflow/run_backlog_grooming](issues/open/workflow/run_backlog_grooming.md) - Run a backlog grooming workflow.
+- [ ] [workflow/run_sprint_retro](issues/open/workflow/run_sprint_retro.md) - Run a sprint retrospective.
+- [ ] [workflow/manage_unassigned_backlog_tasks](issues/open/workflow/manage_unassigned_backlog_tasks.md) - Manage tasks not assigned to a sprint.
+- [ ] [workflow/view_sprint_and_backlog](issues/open/workflow/view_sprint_and_backlog.md) - View the current sprint and unassigned tasks.
+- [ ] [workflow/json_tasks_projection](issues/open/workflow/json_tasks_projection.md) - Provide a JSON projection of tasks.
+- [ ] [workflow/remove_completed_sprint_todos_on_archive](issues/open/workflow/remove_completed_sprint_todos_on_archive.md) - Remove completed sprint TODOs from top level when archiving.

--- a/issues/open/dashboard/view_tasks_and_sprint.md
+++ b/issues/open/dashboard/view_tasks_and_sprint.md
@@ -1,0 +1,3 @@
+# dashboard/view_tasks_and_sprint
+
+Display both the current sprint and all tasks in the dashboard interface.

--- a/issues/open/workflow/json_tasks_projection.md
+++ b/issues/open/workflow/json_tasks_projection.md
@@ -1,0 +1,3 @@
+# workflow/json_tasks_projection
+
+Generate a JSON projection of the current TODO items for integration with other tools.

--- a/issues/open/workflow/manage_unassigned_backlog_tasks.md
+++ b/issues/open/workflow/manage_unassigned_backlog_tasks.md
@@ -1,0 +1,3 @@
+# workflow/manage_unassigned_backlog_tasks
+
+Create a process for tracking tasks that are not yet assigned to a sprint and moving them into a sprint backlog when ready.

--- a/issues/open/workflow/remove_completed_sprint_todos_on_archive.md
+++ b/issues/open/workflow/remove_completed_sprint_todos_on_archive.md
@@ -1,0 +1,3 @@
+# workflow/remove_completed_sprint_todos_on_archive
+
+Remove completed sprint-related entries from the top level TODO.md when archiving a sprint.

--- a/issues/open/workflow/run_backlog_grooming.md
+++ b/issues/open/workflow/run_backlog_grooming.md
@@ -1,0 +1,3 @@
+# workflow/run_backlog_grooming
+
+Document a backlog grooming workflow to regularly review and prioritize outstanding tasks.

--- a/issues/open/workflow/run_sprint_planning.md
+++ b/issues/open/workflow/run_sprint_planning.md
@@ -1,0 +1,3 @@
+# workflow/run_sprint_planning
+
+Provide a workflow for running sprint planning so that backlog items can be selected and prioritized for the upcoming sprint.

--- a/issues/open/workflow/run_sprint_retro.md
+++ b/issues/open/workflow/run_sprint_retro.md
@@ -1,0 +1,3 @@
+# workflow/run_sprint_retro
+
+Outline the steps for conducting a sprint retrospective to identify improvements for future iterations.

--- a/issues/open/workflow/view_sprint_and_backlog.md
+++ b/issues/open/workflow/view_sprint_and_backlog.md
@@ -1,0 +1,3 @@
+# workflow/view_sprint_and_backlog
+
+Allow users to view the current sprint tasks alongside any unassigned backlog items.

--- a/sprints/open/sprint-001/TODO.md
+++ b/sprints/open/sprint-001/TODO.md
@@ -32,3 +32,4 @@ This repository tracks work items in the `../../issues/` directory. Each task be
   - [x] Optional - AI Integration Helper (PR #4)
 - [x] [workflow/sprint-file-validation](../../issues/closed/workflow/sprint-file-validation.md) - Validate sprint files and warn on formatting errors.
 - [x] [workflow/implement-git-transactions](../../issues/closed/workflow/implement-git-transactions.md) - Implement transactional Git workflow scripts and documentation
+- [ ] [workflow/remove_completed_sprint_todos_on_archive](../../issues/open/workflow/remove_completed_sprint_todos_on_archive.md) - Remove completed sprint TODOs from top level when archiving.


### PR DESCRIPTION
## Summary
- add workflow backlog issues and update TODO lists
- keep the cleanup task open until the archive script removes sprint TODOs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853aeeebb648323ab019c65aeba75b3