### PR TITLE
Add workflow diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,4 +112,10 @@ If something goes wrong, run `./scripts/git_transaction.sh rollback`
 to restore the previous state. The helper stashes any pre-existing
 changes, uses a temporary branch for your edits and squashes the
 result into a single commit. See `scripts/transaction_example.py` for
-a Python example. Untracked files are stashed automatically; 
+a Python example. Untracked files are stashed automatically;
+
+## Documentation
+
+Additional diagrams illustrating repository workflows live in
+`docs/workflows/`. They include mermaid charts for the sprint cycle,
+handling individual issues, and meta-sprint planning.

--- a/TODO.md
+++ b/TODO.md
@@ -29,3 +29,4 @@ This repository tracks work items in the `issues/` directory. Each task below li
 - [ ] [workflow/view_sprint_and_backlog](issues/open/workflow/view_sprint_and_backlog.md) - View the current sprint and unassigned tasks.
 - [ ] [workflow/json_tasks_projection](issues/open/workflow/json_tasks_projection.md) - Provide a JSON projection of tasks.
 - [ ] [workflow/remove_completed_sprint_todos_on_archive](issues/open/workflow/remove_completed_sprint_todos_on_archive.md) - Remove completed sprint TODOs from top level when archiving.
+- [x] [workflow/workflow_diagrams](issues/closed/workflow/workflow_diagrams.md) - Document sprint, issue, and meta-sprint workflows.

--- a/docs/workflows/issue_workflow.md
+++ b/docs/workflows/issue_workflow.md
@@ -1,0 +1,19 @@
+# Issue Workflow
+
+```mermaid
+flowchart TD
+    start([Receive Issue]) --> read[Read issue text]
+    read --> meta[Check priority & meta]
+    meta --> category[Check category]
+    category --> inSprint{Part of sprint?}
+    inSprint -->|Yes| sprint[Sprint context]
+    inSprint -->|No| offline[Work offline]
+    sprint --> process[Process issue contents]
+    offline --> process
+    process --> amend{Need amendments?}
+    amend -->|Yes| edit[Amend issue text]
+    edit --> commit[Commit changes]
+    amend -->|No| commit
+    commit --> pr[Open PR]
+    pr --> done([Issue complete])
+```

--- a/docs/workflows/meta_sprint_workflow.md
+++ b/docs/workflows/meta_sprint_workflow.md
@@ -1,0 +1,12 @@
+# Meta-Sprint Workflow
+
+```mermaid
+flowchart TD
+    start([Begin meta-sprint]) --> gather[Gather past sprint data]
+    gather --> review[Review backlog & upcoming work]
+    review --> plan[Plan current sprint]
+    plan --> run[Sprint execution]
+    run --> retro[Sprint retrospective]
+    retro --> update[Update future plans]
+    update --> end([Meta-sprint complete])
+```

--- a/docs/workflows/sprint_workflow.md
+++ b/docs/workflows/sprint_workflow.md
@@ -1,0 +1,11 @@
+# Sprint Workflow
+
+```mermaid
+flowchart TD
+    start([Start sprint]) --> planning[Sprint Planning]
+    planning --> development[Development by agents]
+    development --> review[Code Review & Testing]
+    review --> demo[Sprint Review/Demo]
+    demo --> retro[Sprint Retrospective]
+    retro --> end([Sprint complete])
+```

--- a/issues/closed/workflow/workflow_diagrams.md
+++ b/issues/closed/workflow/workflow_diagrams.md
@@ -1,0 +1,3 @@
+# workflow/workflow_diagrams
+
+Create mermaid diagrams for the sprint, issue, and meta-sprint workflows under `docs/workflows/`.

--- a/sprints/open/sprint-3/TODO.md
+++ b/sprints/open/sprint-3/TODO.md
@@ -22,3 +22,4 @@ This repository tracks work items in the `../../issues/` directory. Each task be
 
 ## Meta/Workflow
 - [ ] [workflow/remove_completed_sprint_todos_on_archive](../../issues/open/workflow/remove_completed_sprint_todos_on_archive.md) - Remove completed sprint TODOs from top level when archiving.
+- [x] [workflow/workflow_diagrams](../../issues/closed/workflow/workflow_diagrams.md) - Document sprint, issue, and meta-sprint workflows.

--- a/sprints/open/sprint-3/sprint-meta.md
+++ b/sprints/open/sprint-3/sprint-meta.md
@@ -3,3 +3,4 @@
 
 ## Issues
 - [ ] [workflow/remove_completed_sprint_todos_on_archive](../../issues/open/workflow/remove_completed_sprint_todos_on_archive.md) - Remove completed sprint TODOs from top level when archiving.
+- [x] [workflow/workflow_diagrams](../../issues/closed/workflow/workflow_diagrams.md) - Document sprint, issue, and meta-sprint workflows.


### PR DESCRIPTION
## Summary
- document sprint, issue, and meta-sprint workflows in `docs/workflows/`
- close new issue tracking the diagrams
- track completion in TODOs and sprint metadata
- mention docs location in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853ba617de083238104bca99b60b845