### PR TITLE
Add CLI render step for workflow diagrams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,4 @@ logs/
 # Node.js
 node_modules/
 **/dist/
+docs/workflows/rendered/

--- a/README.md
+++ b/README.md
@@ -118,4 +118,5 @@ a Python example. Untracked files are stashed automatically;
 
 Additional diagrams illustrating repository workflows live in
 `docs/workflows/`. They include mermaid charts for the sprint cycle,
-handling individual issues, and meta-sprint planning.
+handling individual issues, and meta-sprint planning. See
+`docs/workflows/README.md` for details on generating and viewing them.

--- a/TODO.md
+++ b/TODO.md
@@ -29,4 +29,5 @@ This repository tracks work items in the `issues/` directory. Each task below li
 - [ ] [workflow/view_sprint_and_backlog](issues/open/workflow/view_sprint_and_backlog.md) - View the current sprint and unassigned tasks.
 - [ ] [workflow/json_tasks_projection](issues/open/workflow/json_tasks_projection.md) - Provide a JSON projection of tasks.
 - [ ] [workflow/remove_completed_sprint_todos_on_archive](issues/open/workflow/remove_completed_sprint_todos_on_archive.md) - Remove completed sprint TODOs from top level when archiving.
+- [x] [workflow/view_workflow_diagrams](issues/closed/workflow/view_workflow_diagrams.md) - Provide docs and a script for viewing diagrams.
 - [x] [workflow/workflow_diagrams](issues/closed/workflow/workflow_diagrams.md) - Document sprint, issue, and meta-sprint workflows.

--- a/docs/workflows/README.md
+++ b/docs/workflows/README.md
@@ -1,0 +1,12 @@
+# Viewing Workflow Diagrams
+
+This directory contains mermaid diagrams describing how issues,
+sprints, and meta-sprints are managed in the repository.
+
+## Quick Start
+
+Install Node.js so that the `npx` command is available. Then run
+`./scripts/list_workflow_diagrams.sh` from the repository root. The
+script uses the Mermaid CLI to render each workflow diagram as an SVG
+under `docs/workflows/rendered/` and prints a `file://` URL for each
+generated image. Open those links in your browser to view the charts.

--- a/issues/closed/workflow/view_workflow_diagrams.md
+++ b/issues/closed/workflow/view_workflow_diagrams.md
@@ -1,0 +1,5 @@
+# workflow/view_workflow_diagrams
+
+Add documentation explaining how to view the workflow diagrams in
+`docs/workflows/` and a script that renders them with the Mermaid CLI
+before outputting browser-friendly links.

--- a/scripts/list_workflow_diagrams.sh
+++ b/scripts/list_workflow_diagrams.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Render Mermaid workflow diagrams as SVG and list file URLs.
+
+set -e
+
+DOC_DIR="$(dirname "$0")/../docs/workflows"
+DOC_DIR="$(realpath "$DOC_DIR")"
+OUT_DIR="$DOC_DIR/rendered"
+
+mkdir -p "$OUT_DIR"
+
+if ! command -v npx >/dev/null 2>&1; then
+  echo "npx is required to run mermaid-cli. Install Node.js." >&2
+  exit 1
+fi
+
+for md in "$DOC_DIR"/*_workflow.md; do
+  base=$(basename "$md" .md)
+  out="$OUT_DIR/${base}.svg"
+  npx -y @mermaid-js/mermaid-cli -i "$md" -o "$out" >/dev/null
+  echo "file://$out"
+done


### PR DESCRIPTION
## Summary
- update workflow docs with Node requirement and render instructions
- ignore generated diagrams
- render diagrams using mermaid CLI before listing them
- clarify closed issue description

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853bbbe90f88323a0102dc4daea04f4