### PR TITLE
Implement sprint archiving cleanup

### DIFF
--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -1,0 +1,13 @@
+# Issue Template
+
+## Summary
+
+(Briefly describe the issue or feature request)
+
+## Steps to Reproduce / Implementation Plan
+
+(Outline steps or plan)
+
+## Additional Context
+
+(Any other relevant information) 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+# Pull Request Template
+
+## Summary
+
+(Describe the changes in this PR)
+
+## Related Issues
+
+(List any related issues or tasks)
+
+## Checklist
+- [ ] Tests added/updated
+- [ ] Documentation updated
+- [ ] Code follows style guidelines 

--- a/tests/test_archive_sprint.py
+++ b/tests/test_archive_sprint.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import scripts.archive_sprint as arch
+
+
+def test_archive_removes_todo(tmp_path):
+    repo = tmp_path
+    (repo / "issues/open/workflow").mkdir(parents=True)
+    (repo / "issues/open/workflow/foo.md").write_text("issue")
+
+    sprint_dir = repo / "sprints/open/sprint1"
+    sprint_dir.mkdir(parents=True)
+    sprint_meta = sprint_dir / "sprint-meta.md"
+    sprint_meta.write_text(
+        "# Sprint\n\n## Issues\n- [ ] [workflow/foo](../../issues/open/workflow/foo.md)\n"
+    )
+
+    todo = repo / "TODO.md"
+    todo.write_text(
+        "- [ ] [workflow/foo](issues/open/workflow/foo.md) - desc\n"
+    )
+
+    # patch constants
+    arch.ROOT = repo
+    arch.SPRINT_OPEN = repo / "sprints" / "open"
+    arch.SPRINT_ARCHIVED = repo / "sprints" / "archived"
+
+    arch.archive_sprint("sprint1")
+
+    assert "workflow/foo" not in todo.read_text()
+    assert (repo / "sprints/archived/sprint1").is_dir()
+


### PR DESCRIPTION
## Summary
- remove sprint items from TODO when archiving
- add unit test for archive cleanup
- provide contribution templates for GitHub

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853c22e10c08323a3bd3efab0827f28