### PR TITLE
Add script for automated issue creation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -39,3 +39,7 @@ This repository tracks work items in the `issues/` directory. Each task below li
 - [ ] [workflow/improve_sprint_issue_scripts](issues/open/workflow/improve_sprint_issue_scripts.md) - Write or improve scripts for sprint and issue management.
 - [ ] [workflow/add_contribution_templates](issues/open/workflow/add_contribution_templates.md) - Add templates for issues, PRs, and sprints.
 - [x] [workflow/manually-update-issue-metadata](issues/closed/workflow/manually-update-issue-metadata.md) - Ensure all issues have up-to-date metadata headers.
+- [ ] [workflow/basic_issue_creator_script](issues/open/workflow/basic_issue_creator_script.md) - TBD
+- [ ] [workflow/issue_category_tag_list](issues/open/workflow/issue_category_tag_list.md) - TBD
+- [ ] [workflow/agent_autofill_issue_details](issues/open/workflow/agent_autofill_issue_details.md) - TBD
+- [ ] [workflow/agent_smart_issue_creator](issues/open/workflow/agent_smart_issue_creator.md) - TBD

--- a/issues/open/workflow/agent_autofill_issue_details.md
+++ b/issues/open/workflow/agent_autofill_issue_details.md
@@ -1,0 +1,14 @@
+---
+status: open
+category: workflow
+tags:
+  - placeholder
+created: 2025-06-19
+last-updated: 2025-06-19
+priority: medium
+assigned: unassigned
+------------------------
+
+# workflow/agent_autofill_issue_details
+
+TBD

--- a/issues/open/workflow/agent_smart_issue_creator.md
+++ b/issues/open/workflow/agent_smart_issue_creator.md
@@ -1,0 +1,14 @@
+---
+status: open
+category: workflow
+tags:
+  - placeholder
+created: 2025-06-19
+last-updated: 2025-06-19
+priority: medium
+assigned: unassigned
+------------------------
+
+# workflow/agent_smart_issue_creator
+
+TBD

--- a/issues/open/workflow/basic_issue_creator_script.md
+++ b/issues/open/workflow/basic_issue_creator_script.md
@@ -1,0 +1,14 @@
+---
+status: open
+category: workflow
+tags:
+  - placeholder
+created: 2025-06-19
+last-updated: 2025-06-19
+priority: medium
+assigned: unassigned
+------------------------
+
+# workflow/basic_issue_creator_script
+
+TBD

--- a/issues/open/workflow/issue_category_tag_list.md
+++ b/issues/open/workflow/issue_category_tag_list.md
@@ -1,0 +1,14 @@
+---
+status: open
+category: workflow
+tags:
+  - placeholder
+created: 2025-06-19
+last-updated: 2025-06-19
+priority: medium
+assigned: unassigned
+------------------------
+
+# workflow/issue_category_tag_list
+
+TBD

--- a/scripts/create_issue.py
+++ b/scripts/create_issue.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Create a new issue file and update TODO lists."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import date
+from pathlib import Path
+import json
+
+ROOT = Path(__file__).resolve().parents[1]
+ISSUES_DIR = ROOT / "issues" / "open"
+TODO_PATH = ROOT / "TODO.md"
+STATE_PATH = ROOT / "state" / "sprint.json"
+
+CATEGORY_HEADINGS = {
+    "dashboard": "## Dashboard",
+    "agents": "## Agents",
+    "cross": "## Cross-cutting",
+    "bus": "## Event Bus",
+    "workflow": "## Meta/Workflow",
+}
+
+
+def insert_line(path: Path, heading: str, line: str) -> None:
+    """Insert a line into a markdown list under the given heading."""
+    lines = path.read_text().splitlines()
+    if heading not in lines:
+        lines.extend(["", heading, line])
+    else:
+        idx = lines.index(heading) + 1
+        while idx < len(lines) and not lines[idx].startswith("## "):
+            idx += 1
+        lines.insert(idx, line)
+    path.write_text("\n".join(lines) + "\n")
+
+
+def create_issue(category: str, name: str) -> None:
+    today = date.today().isoformat()
+    issue_path = ISSUES_DIR / category / f"{name}.md"
+    issue_path.parent.mkdir(parents=True, exist_ok=True)
+
+    content = f"""---
+status: open
+category: {category}
+tags:
+  - placeholder
+created: {today}
+last-updated: {today}
+priority: medium
+assigned: unassigned
+------------------------
+
+# {category}/{name}
+
+TBD
+"""
+    issue_path.write_text(content)
+
+    line = f"- [ ] [{category}/{name}](issues/open/{category}/{name}.md) - TBD"
+    heading = CATEGORY_HEADINGS.get(category, f"## {category.title()}")
+    insert_line(TODO_PATH, heading, line)
+
+    state = json.loads(STATE_PATH.read_text())
+    sprint_dir = ROOT / "sprints" / "open" / f"sprint-{state['current']}"
+    sprint_todo = sprint_dir / "TODO.md"
+    sprint_meta = sprint_dir / "sprint-meta.md"
+    insert_line(sprint_todo, heading, line.replace("issues/open/", "../../issues/open/"))
+    insert_line(sprint_meta, "## Issues", line.replace("issues/open/", "../../issues/open/"))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="create issue")
+    parser.add_argument("category", help="issue category")
+    parser.add_argument("name", help="issue name (without .md)")
+    args = parser.parse_args()
+    create_issue(args.category, args.name)

--- a/sprints/open/sprint-3/TODO.md
+++ b/sprints/open/sprint-3/TODO.md
@@ -11,3 +11,7 @@ This sprint focuses on establishing clear workflows, documentation, and onboardi
 - [x] [workflow/manually-update-issue-metadata](../../issues/closed/workflow/manually-update-issue-metadata.md) - Ensure all issues have up-to-date metadata headers.
 - [ ] [workflow/remove_completed_sprint_todos_on_archive](../../issues/open/workflow/remove_completed_sprint_todos_on_archive.md) - Remove completed sprint TODOs from top level when archiving.
 - [x] [workflow/workflow_diagrams](../../issues/closed/workflow/workflow_diagrams.md) - Document sprint, issue, and meta-sprint workflows.
+- [ ] [workflow/basic_issue_creator_script](../../issues/open/workflow/basic_issue_creator_script.md) - TBD
+- [ ] [workflow/issue_category_tag_list](../../issues/open/workflow/issue_category_tag_list.md) - TBD
+- [ ] [workflow/agent_autofill_issue_details](../../issues/open/workflow/agent_autofill_issue_details.md) - TBD
+- [ ] [workflow/agent_smart_issue_creator](../../issues/open/workflow/agent_smart_issue_creator.md) - TBD

--- a/sprints/open/sprint-3/sprint-meta.md
+++ b/sprints/open/sprint-3/sprint-meta.md
@@ -5,3 +5,7 @@
 - [ ] [workflow/remove_completed_sprint_todos_on_archive](../../issues/open/workflow/remove_completed_sprint_todos_on_archive.md) - Remove completed sprint TODOs from top level when archiving.
 - [x] [workflow/manually-update-issue-metadata](../../issues/closed/workflow/manually-update-issue-metadata.md) - Ensure all issues have up-to-date metadata headers.
 - [x] [workflow/workflow_diagrams](../../issues/closed/workflow/workflow_diagrams.md) - Document sprint, issue, and meta-sprint workflows.
+- [ ] [workflow/basic_issue_creator_script](../../issues/open/workflow/basic_issue_creator_script.md) - TBD
+- [ ] [workflow/issue_category_tag_list](../../issues/open/workflow/issue_category_tag_list.md) - TBD
+- [ ] [workflow/agent_autofill_issue_details](../../issues/open/workflow/agent_autofill_issue_details.md) - TBD
+- [ ] [workflow/agent_smart_issue_creator](../../issues/open/workflow/agent_smart_issue_creator.md) - TBD


### PR DESCRIPTION
## Summary
- automate adding new tasks with `scripts/create_issue.py`
- generate issue files for future automation improvements
- append generated issues to TODO and active sprint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685435b86358832397048887861c966c