### PR TITLE
Add unified test runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+./scripts/run_all_tests.sh

--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ EcoNexyz is an ecological system of autonomous AI agents that can be registered,
 
 Visit `http://localhost:8000/` for instructions, `http://localhost:8000/status` to see agent status and `http://localhost:8000/messages` for recent bus messages.
 
+## Running Tests
+
+Use the unified script to run all project tests:
+
+```bash
+./scripts/run_all_tests.sh
+```
+
+Alternatively, if `make` is available:
+
+```bash
+make test
+```
+
+The script executes the Python unit tests and the commit hook checks, exiting
+with a non‑zero status if any test fails.
+
 ## bootstrap.sh: Environment Setup & Agent Runner
 
 The `bootstrap.sh` script automates the following:

--- a/agent-logs/agent.20250620T012801Z.log.md
+++ b/agent-logs/agent.20250620T012801Z.log.md
@@ -1,0 +1,8 @@
+# Agent Log 2025-06-20
+
+## Overview
+
+Implemented the unified test runner described in `workflow/run_all_tests_script`.
+Added `scripts/run_all_tests.sh`, a `Makefile` test target, and updated the
+`README` with usage instructions. The script runs Python tests and the commit
+hook checks, returning a non-zero status if any fail.

--- a/scripts/run_all_tests.sh
+++ b/scripts/run_all_tests.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Unified test runner for EcoNexyz
+
+set -euo pipefail
+
+GREEN="\033[0;32m"
+RED="\033[0;31m"
+NC="\033[0m" # No Color
+
+PASS=true
+
+echo -e "${GREEN}==> Running Python tests${NC}"
+if pytest; then
+    echo -e "${GREEN}Python tests passed${NC}"
+else
+    echo -e "${RED}Python tests failed${NC}"
+    PASS=false
+fi
+
+echo -e "${GREEN}==> Running commit hook tests${NC}"
+set +e
+PYTHONPATH="${PYTHONPATH:-}:$(pwd)" python scripts/test_commit_hook.py
+HOOK_STATUS=$?
+set -e
+if [ $HOOK_STATUS -eq 0 ]; then
+    echo -e "${GREEN}Commit hook tests passed${NC}"
+else
+    echo -e "${RED}Commit hook tests failed${NC}"
+    PASS=false
+fi
+
+if [ "$PASS" = true ]; then
+    echo -e "${GREEN}All tests passed${NC}"
+    exit 0
+else
+    echo -e "${RED}One or more tests failed${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- add `run_all_tests.sh` for running all tests
- expose a `test` target in a new Makefile
- document how to run tests in the README
- log actions in agent log

## Testing
- `./scripts/run_all_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_6854b89c131c8323bba6aa0d3706a83b