### PR TITLE
Add issue date update pre-commit hook

### DIFF
--- a/agent-logs/agent.20250620T012811Z.log.md
+++ b/agent-logs/agent.20250620T012811Z.log.md
@@ -1,0 +1,4 @@
+# Agent Log 2025-06-20
+
+## Overview
+Implemented automatic updating of issue `last-updated` fields via a new pre-commit hook. Added tests for the script and integrated the hook installation.

--- a/scripts/pre_commit.sh
+++ b/scripts/pre_commit.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Pre-commit hook to update issue metadata and warn on locked files
+set -e
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+python "$REPO_ROOT/scripts/update_issue_dates.py"
+python "$REPO_ROOT/scripts/pre_commit_lock.py"

--- a/scripts/setup_hooks.sh
+++ b/scripts/setup_hooks.sh
@@ -18,13 +18,13 @@ echo "Installing commit-msg hook..."
 cp "$SCRIPT_DIR/commit-msg-hook.py" "$HOOKS_DIR/commit-msg"
 chmod +x "$HOOKS_DIR/commit-msg"
 
-# Install pre-commit hook for lock checking
+# Install pre-commit hook for issue date updates and lock checks
 echo "Installing pre-commit hook..."
-cp "$SCRIPT_DIR/pre_commit_lock.py" "$HOOKS_DIR/pre-commit"
+cp "$SCRIPT_DIR/pre_commit.sh" "$HOOKS_DIR/pre-commit"
 chmod +x "$HOOKS_DIR/pre-commit"
 
 echo "✅ Git hooks installed successfully!"
 
 echo "The commit-msg hook will now validate your commit messages."
-echo "The pre-commit hook will warn if you modify locked files."
-echo "To test, try making a commit with an invalid message or editing a locked file."
+echo "The pre-commit hook updates issue dates and warns about locked files."
+echo "To test, try editing an issue file or a locked file before committing."

--- a/scripts/update_issue_dates.py
+++ b/scripts/update_issue_dates.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Update last-updated fields for staged issue files."""
+from __future__ import annotations
+
+import subprocess
+from datetime import date
+from pathlib import Path
+import re
+
+
+def get_repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return Path(result.stdout.strip()) if result.returncode == 0 else Path.cwd()
+
+
+def get_staged_files(repo: Path) -> list[Path]:
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    files = [repo / f for f in result.stdout.splitlines() if f.startswith("issues/") and f.endswith(".md")]
+    return files
+
+
+def update_file(path: Path, today: str) -> bool:
+    text = path.read_text()
+    if "last-updated:" not in text:
+        return False
+    new_text = re.sub(r"^last-updated:.*", f"last-updated: {today}", text, flags=re.MULTILINE)
+    if new_text != text:
+        path.write_text(new_text)
+        return True
+    return False
+
+
+def main() -> None:
+    repo = get_repo_root()
+    files = get_staged_files(repo)
+    if not files:
+        return
+    today = date.today().isoformat()
+    updated = False
+    for f in files:
+        if f.exists() and update_file(f, today):
+            updated = True
+            subprocess.run(["git", "add", str(f)], cwd=repo, check=False)
+    if updated:
+        print("updated issue last-updated fields")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_update_issue_dates.py
+++ b/tests/test_update_issue_dates.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+import subprocess
+from datetime import date
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "update_issue_dates.py"
+
+
+def init_repo(path: Path) -> None:
+    subprocess.run(["git", "init"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "tester"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "tester@example.com"], cwd=path, check=True)
+
+
+def create_issue(repo: Path) -> Path:
+    issue_dir = repo / "issues" / "open" / "workflow"
+    issue_dir.mkdir(parents=True)
+    issue = issue_dir / "foo.md"
+    issue.write_text(
+        "---\n"
+        "status: open\n"
+        "category: workflow\n"
+        "created: 2025-06-18\n"
+        "last-updated: 2025-06-18\n"
+        "priority: medium\n"
+        "assigned: unassigned\n"
+        "---\n"
+        "# workflow/foo\n"
+    )
+    return issue
+
+
+def test_update_issue_dates(tmp_path):
+    repo = tmp_path
+    init_repo(repo)
+    issue = create_issue(repo)
+    subprocess.run(["git", "add", str(issue)], cwd=repo, check=True)
+    subprocess.run(["python", str(SCRIPT)], cwd=repo, check=True)
+    text = issue.read_text()
+    assert f"last-updated: {date.today().isoformat()}" in text


### PR DESCRIPTION
## Summary
- update issue files' `last-updated` field automatically
- add a pre-commit hook calling the updater and lock checker
- install new hook via `setup_hooks.sh`
- test the updater script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b8a602f08323a5c0eaed2904f40c