### PR TITLE
Add SmartIssueCreatorAgent prototype

### DIFF
--- a/agent-logs/agent.20250620T012845Z.log.md
+++ b/agent-logs/agent.20250620T012845Z.log.md
@@ -1,0 +1,5 @@
+# Agent Log 2025-06-20
+
+## Overview
+
+Implemented the initial prototype for `SmartIssueCreatorAgent` which listens for `issue_request` messages and generates issue files using heuristics. Updated `agents/__init__.py` to export the new agent and expanded the `agent_smart_issue_creator` issue with an implementation plan.

--- a/econexyz/agents/__init__.py
+++ b/econexyz/agents/__init__.py
@@ -2,5 +2,6 @@
 
 from .sample import SampleAgent
 from .weather import WeatherAgent
+from .issue_creator import SmartIssueCreatorAgent
 
-__all__ = ["SampleAgent", "WeatherAgent"]
+__all__ = ["SampleAgent", "WeatherAgent", "SmartIssueCreatorAgent"]

--- a/econexyz/agents/issue_creator.py
+++ b/econexyz/agents/issue_creator.py
@@ -1,0 +1,77 @@
+"""Agent that creates issue files from short descriptions."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+import time
+from pathlib import Path
+from typing import Dict, Any, Optional
+
+from econexyz.message_bus.base import MessageBus
+from econexyz.storage.base import KnowledgeStore
+from .base import Agent
+
+import sys
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+from scripts import create_issue
+
+
+class SmartIssueCreatorAgent(Agent):
+    """Generate issue files from simple requests."""
+
+    def __init__(
+        self,
+        name: str,
+        bus: MessageBus,
+        store: KnowledgeStore,
+        config_path: Optional[Path] = None,
+    ) -> None:
+        super().__init__(name, bus, store)
+        self.config_path = config_path or Path(__file__).resolve().parents[2] / "config" / "issue_categories.yml"
+        self.categories = create_issue.load_categories()
+        self.bus.subscribe("issue_request", self.handle_request)
+
+    def run(self) -> None:
+        """Idle loop waiting for messages."""
+        logging.info("%s listening for issue requests", self.name)
+        while self.running:
+            time.sleep(0.1)
+
+    def _choose_category(self, description: str) -> str:
+        """Return a category based on simple heuristics."""
+        text = description.lower()
+        if "bug" in text or "error" in text:
+            return "bugs"
+        if "dashboard" in text:
+            return "dashboard"
+        if "agent" in text:
+            return "agents"
+        if "bus" in text:
+            return "bus"
+        return "workflow"
+
+    def handle_request(self, message: Dict[str, Any]) -> None:
+        """Process an issue creation request message."""
+        desc = message.get("description", "").strip()
+        if not desc:
+            logging.warning("%s received empty description", self.name)
+            return
+
+        category = message.get("category") or self._choose_category(desc)
+        tags = message.get("tags") or self.categories.get(category, {}).get("tags", [])
+        priority = message.get("priority", "medium")
+
+        name = "_".join(desc.lower().split())[:30]
+        today = date.today().isoformat()
+        content = create_issue.render_content(category, name, tags, priority, today)
+        print(content)
+        approve = input("Create this issue? [y/N] ")
+        if approve.lower().startswith("y"):
+            create_issue.create_issue(category, name, tags=tags, priority=priority)
+            self.store.save(name, {"category": category, "created": today})
+            logging.info("%s created issue %s/%s", self.name, category, name)
+        else:
+            logging.info("%s cancelled issue creation", self.name)
+

--- a/issues/open/workflow/agent_smart_issue_creator.md
+++ b/issues/open/workflow/agent_smart_issue_creator.md
@@ -40,3 +40,19 @@ language model or external services.
 - Add a new backburner issue to design an interactive multi-commit workflow on a
   development branch that can later be squashed onto main.
 - Store configuration for categories and tags in `config/issue_categories.yml` to reuse across the project.
+
+## Implementation Plan (PR Breakdown)
+
+### PR #1: Initial Agent Prototype
+- [x] Create `SmartIssueCreatorAgent` with basic heuristics for category selection.
+- [x] Load tag suggestions from `config/issue_categories.yml`.
+- [x] Integrate with `create_issue.py` and prompt user for approval before writing files.
+
+### PR #2: Context Plugins
+- [ ] Define plugin interface for gathering repository context.
+- [ ] Implement simple plugins for scanning README and open issues.
+- [ ] Add unit tests for plugin loading and execution.
+
+### PR #3: Advanced Language Model Support
+- [ ] Add optional integration with a language model API for draft generation.
+- [ ] Provide configuration and error handling for external service calls.

--- a/tests/test_issue_creator_agent.py
+++ b/tests/test_issue_creator_agent.py
@@ -1,0 +1,47 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from econexyz.agents.issue_creator import SmartIssueCreatorAgent
+from econexyz.message_bus.in_memory import InMemoryMessageBus
+from econexyz.storage.sqlite_store import SQLiteKnowledgeStore
+import scripts.create_issue as ci
+
+
+def setup_repo(tmp_path: Path):
+    (tmp_path / "issues/open").mkdir(parents=True)
+    (tmp_path / "config").mkdir()
+    (tmp_path / "docs/templates").mkdir(parents=True)
+    (tmp_path / "docs/templates/issue_template.md").write_text("body")
+    (tmp_path / "TODO.md").write_text("")
+    config = '{"workflow": {"tags": ["workflow"]}, "bugs": {"tags": ["bug"]}}'
+    (tmp_path / "config/issue_categories.yml").write_text(config)
+
+    ci.ROOT = tmp_path
+    ci.ISSUES_DIR = tmp_path / "issues" / "open"
+    ci.TODO_PATH = tmp_path / "TODO.md"
+    ci.CONFIG_PATH = tmp_path / "config" / "issue_categories.yml"
+    ci.TEMPLATES_DIR = tmp_path / "docs" / "templates"
+
+
+def test_choose_category():
+    bus = InMemoryMessageBus()
+    store = SQLiteKnowledgeStore(":memory:")
+    agent = SmartIssueCreatorAgent("tester", bus, store)
+    assert agent._choose_category("Fix bug in login") == "bugs"
+    assert agent._choose_category("Update dashboard colors") == "dashboard"
+
+
+def test_handle_request_creates_issue(tmp_path, monkeypatch):
+    setup_repo(tmp_path)
+    bus = InMemoryMessageBus()
+    db = tmp_path / "store.db"
+    store = SQLiteKnowledgeStore(str(db))
+    monkeypatch.setattr("builtins.input", lambda _: "y")
+    agent = SmartIssueCreatorAgent("creator", bus, store, config_path=ci.CONFIG_PATH)
+    bus.publish("issue_request", {"description": "fix login bug", "priority": "low"})
+    issue_file = tmp_path / "issues/open/bugs/fix_login_bug.md"
+    assert issue_file.exists()
+    text = issue_file.read_text()
+    assert "priority: low" in text


### PR DESCRIPTION
## Summary
- implement `SmartIssueCreatorAgent` for turning short descriptions into issues
- export the new agent
- lay out a multi-PR implementation plan in the issue
- add tests for the new agent
- log the agent activity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854b8b9f7a083239439976362abcd6d