### PR TITLE
Add bootstrap.sh script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,21 @@ curl -sL https://api.github.com/repos/plva/econexyz/issues/<NUMBER>
 ```
 
 For background on our tooling choices see [docs/adr/index.md](docs/adr/index.md). Any design decision affecting repository tooling must include a new ADR.
+
+## Quickstart
+
+Clone the repository and run the bootstrap script:
+
+```bash
+git clone https://github.com/plva/econexyz
+cd econexyz
+./bootstrap.sh
+```
+
+Run a task inside the environment:
+
+```bash
+./bootstrap.sh test
+```
+
+The script creates `.venv` with [uv](https://github.com/astral-sh/uv) and installs pre-commit hooks. Run `./bootstrap.sh --help` for usage details.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: ./bootstrap.sh [ARGS...]
+
+Bootstraps the project using a local Python virtual environment.
+Additional arguments are executed within the environment.
+USAGE
+}
+
+if [[ ${1-} == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+# Ensure we are in the repo root
+cd "$(dirname "$0")"
+
+# Install uv if missing
+if ! command -v uv >/dev/null 2>&1; then
+  echo "Installing uv..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+
+# Create or reuse virtual environment
+if [ ! -d .venv ]; then
+  python3 -m venv .venv
+fi
+
+# Activate environment
+source .venv/bin/activate
+
+# Install dependencies if lock file exists
+if [ -f uv.lock ]; then
+  uv pip install -r uv.lock
+elif [ -f pyproject.toml ]; then
+  uv pip install -e .
+fi
+
+# Install pre-commit hooks if available
+if ! command -v pre-commit >/dev/null 2>&1; then
+  uv pip install pre-commit
+fi
+pre-commit install --install-hooks >/dev/null 2>&1 || true
+
+# Forward arguments to the given command if provided
+if [ "$#" -gt 0 ]; then
+  "$@"
+else
+  usage
+fi


### PR DESCRIPTION
## Summary
- add a portable `bootstrap.sh` helper for local setup
- document bootstrap usage in README

## Testing
- `./bootstrap.sh --help`
- `./bootstrap.sh`

------
https://chatgpt.com/codex/tasks/task_e_68589636d21083238e21a9dd76d6909f