### PR TITLE
Implement issue 71 p1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,16 @@ Use `--yes-hooks` or `--no-hooks` to skip the prompt. Run `./bootstrap.sh --help
 
 ## Command palette
 
-A `Justfile` in the repo root defines commands like `just test` and `just lint`. These recipes currently print TODO messages and will be wired up in a future phase.
+Run `./bootstrap.sh` to set up the environment. The script now installs the
+[`just`](https://github.com/casey/just) task runner so you can execute recipes
+defined in the `Justfile`:
+
+```bash
+just --list
+```
+
+The current recipes still print TODO placeholders until the next phase wires in
+real commands.
 
 
 ### Development container (preview)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -39,6 +39,12 @@ if ! command -v uv >/dev/null 2>&1; then
   curl -LsSf https://astral.sh/uv/install.sh | sh
 fi
 
+# Install just if missing
+if ! command -v just >/dev/null 2>&1; then
+  echo "Installing just..."
+  uv tool install just
+fi
+
 # Create or reuse virtual environment
 if [ ! -d .venv ]; then
   python3 -m venv .venv


### PR DESCRIPTION
## Summary
- install `just` in `bootstrap.sh`
- document how to use the command palette in the README

## Testing
- `./bootstrap.sh --no-hooks just --version`
- `just --list`


------
https://chatgpt.com/codex/tasks/task_e_6858a9ae73b08323862c1736f14e6ca2