### PR TITLE
Add contributor experience kit

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,26 @@
+name: Bug Report
+description: Report a reproducible bug
+labels:
+  - bug
+body:
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+      description: Describe how to reproduce the issue.
+  - type: textarea
+    attributes:
+      label: Expected vs Actual
+      description: What you expected to happen and what actually happened.
+  - type: textarea
+    attributes:
+      label: Logs
+      description: Include any relevant logs or screenshots.
+  - type: dropdown
+    attributes:
+      label: Subsystem
+      description: Which part of the project is affected?
+      options:
+        - agent
+        - core
+        - docs
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,18 @@
+name: Feature Request
+description: Suggest an enhancement or new feature
+labels:
+  - feature
+body:
+  - type: textarea
+    attributes:
+      label: Problem Statement
+      description: What problem are you trying to solve?
+  - type: textarea
+    attributes:
+      label: Proposed Solution
+      description: Describe your preferred solution.
+  - type: textarea
+    attributes:
+      label: Alternatives Considered
+      description: List any alternative solutions you've considered.
+

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,10 @@
+name: Question
+description: Ask a question about the project
+labels:
+  - question
+body:
+  - type: textarea
+    attributes:
+      label: Question
+      description: Feel free to ask anything. We also encourage you to use GitHub Discussions.
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+## Checklist
+
+- [ ] Follows Conventional Commits
+- [ ] `just lint && just test` pass locally
+- [ ] Docs/CHANGELOG updated if needed
+
+Please link any related issues and apply appropriate labels.
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,36 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints
+
+Examples of unacceptable behavior by participants include:
+
+* Trolling, insulting/derogatory comments, and personal attacks
+* Public or private harassment
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior.
+
+## Scope
+
+This Code of Conduct applies within all project spaces and in public spaces when an individual is representing the project.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainers at <maintainers@yourorg.com>.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org) version 2.1.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing
+
+Thank you for wanting to contribute! Follow these steps to get started.
+
+## Setup
+
+Run the bootstrap script which sets up a virtual environment and installs dependencies:
+
+```bash
+./bootstrap.sh
+```
+
+You can then run lint and tests:
+
+```bash
+just lint
+just test
+```
+
+## Commit
+
+Use Commitizen to craft commit messages:
+
+```bash
+just commit
+```
+
+## Pull Requests
+
+Before opening a PR ensure:
+
+- `just lint && just test` run successfully
+- Documentation and CHANGELOG are updated when relevant
+- Labels are applied to help triage
+
+

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ just --list
 The current recipes still print TODO placeholders until the next phase wires in
 real commands.
 
+## How to contribute
+
+We welcome contributions from everyone. Please read
+[CONTRIBUTING.md](CONTRIBUTING.md) for setup and workflow details and review our
+[Code of Conduct](CODE_OF_CONDUCT.md) before participating.
+
 
 ### Development container (preview)
 


### PR DESCRIPTION
## Summary
- add CONTRIBUTING guidelines and Code of Conduct
- add issue and PR templates
- document how to contribute in README

## Testing
- `/usr/bin/just lint`
- `/usr/bin/just test`


------
https://chatgpt.com/codex/tasks/task_e_6858aaee17e88323997409e83e92f7a1