### PR TITLE
Implement P0 from issue 106

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# Python build & cache (ADR0007 L31)
+__pycache__/
+.venv/
+.nox/
+.pytest_cache/
+.coverage
+.hypothesis/
+.mypy_cache/
+.ruff_cache/
+.pytype/
+
+# Packaging artifacts (ADR0007 L32)
+dist/
+build/
+*.egg-info/
+wheelhouse/
+*.whl
+*.egg
+
+# Editor/IDE noise (ADR0007 L33)
+.vscode/
+.idea/
+.DS_Store
+*.swp
+*.swo
+*.bak
+
+# Container & SBOM outputs (ADR0007 L34)
+*.sbom.json
+*.sbom.spdx
+sbom/
+trivy-report*.txt
+docker-cache/
+*.tar.zst
+
+# Docs & coverage artefacts (ADR0007 L35)
+docs/_build/
+site/
+htmlcov/
+*.png.auto-gen
+*.svg.auto-gen

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,5 +32,6 @@ Before opening a PR ensure:
 - `just lint && just test` run successfully
 - Documentation and CHANGELOG are updated when relevant
 - Labels are applied to help triage
+- See [ADR 0007](docs/adr/0007-contributor-experience-kit.md#ignored-artefacts-strategy) for repository ignore rules.
 
 

--- a/docs/adr/0007-contributor-experience-kit.md
+++ b/docs/adr/0007-contributor-experience-kit.md
@@ -22,3 +22,17 @@ External contributors—including AI agents—benefit from clear templates and r
 
 * Higher-quality issues/PRs.
 * Slight repo noise; acceptable trade-off.
+
+## Ignored Artefacts Strategy
+
+Ephemeral build outputs and editor settings clutter reviews. We only version
+source files so that diffs stay focused on real changes.
+
+- *Python build & cache* – caches and virtual environments.
+- *Packaging artifacts* – wheels, eggs and build dirs.
+- *Editor/IDE noise* – local IDE state like `.vscode`.
+- *Container & SBOM outputs* – SBOM and container caches.
+- *Docs & coverage artefacts* – built docs and coverage reports.
+
+New patterns must update this list and `.gitignore`. IDE-specific rules belong
+under the "Editor/IDE noise" block.


### PR DESCRIPTION
## Summary
- add project-wide .gitignore tuned for Python, containers, docs
- document ignore rationale in ADR 0007
- link ADR 0007 from CONTRIBUTING

## Testing
- `just lint` *(fails: command not found)*
- `just test` *(fails: command not found)*
- `nox -s tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858b09cef34832396fe6bdf49eb8d08