### PR TITLE
docs(templates): add GitHub issue template for structured stories

### DIFF
--- a/.github/ISSUE_TEMPLATE/story.yml
+++ b/.github/ISSUE_TEMPLATE/story.yml
@@ -1,0 +1,39 @@
+name: "\ud83d\udcdd Story"
+description: Carve work into P0 / P1 units with acceptance checks
+labels:
+  - story
+  - triage
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## STORY — <Action>
+
+        ### Goal
+        <why we need it>
+
+        | Phase | Purpose |
+        |-------|---------|
+        | P0 | ... |
+        | P1 | ... |
+
+        #### P0 Work items
+        - …
+
+        #### P0 Acceptance
+        - …
+
+        #### P1 Work items
+        - …
+
+        #### P1 Acceptance
+        - …
+
+        **Dependencies**: …
+
+        <!-- Optional: uncomment if this story introduces a new strategic choice -->
+        <!--
+        ### Requires ADR
+        *Title idea*: <short phrase>
+        *Rationale*: <1-2 sentences>
+        -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,4 +33,10 @@ Before opening a PR ensure:
 - Documentation and CHANGELOG are updated when relevant
 - Labels are applied to help triage
 
+## Story template
+
+Use the [Story issue template](.github/ISSUE_TEMPLATE/story.yml) when proposing
+new work. Each story should stand on its own with clear P0/P1 sections and
+acceptance criteria.
+
 


### PR DESCRIPTION
## Summary
- add a structured story issue template
- mention the template in CONTRIBUTING docs

## Testing
- `just lint`
- `just test`


------
https://chatgpt.com/codex/tasks/task_e_6858b17bb5e4832390e0f4ac6bedeb33