### PR TITLE
Add BDD demo with pytest-bdd

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,23 @@ We welcome contributions from everyone. Please read
 Clone the repo with VS Code and choose **"Reopen in Container"**.
 First boot runs `bootstrap.sh`; afterwards all `just` commands such as
 `just test`, `just lint`, and `just docs` are available.
+
+## Behaviour-Driven tests
+
+Add behaviour specs under `tests/features/` using `.feature` files:
+
+```gherkin
+Scenario: add two numbers
+  Given two integers
+  When I add them
+  Then the result equals the sum
+```
+
+Run the suite with:
+
+```bash
+nox -s tests
+```
+
+Non-developers can introduce new behaviour by copying a feature file and writing
+English steps only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ authors = [{name = "EcoNexyz"}]
 [project.optional-dependencies]
 test = [
     "pytest",
+    "pytest-bdd",
+    "hypothesis",
     "pytest-cov",
 ]
 dev = [

--- a/tests/features/addition.feature
+++ b/tests/features/addition.feature
@@ -1,0 +1,5 @@
+Feature: Addition
+  Scenario: add two numbers
+    Given two integers
+    When I add them
+    Then the result equals the sum

--- a/tests/test_addition.py
+++ b/tests/test_addition.py
@@ -1,0 +1,23 @@
+# demo for issue 54
+from hypothesis import strategies as st
+from pytest_bdd import given, scenario, then, when
+
+
+@scenario("features/addition.feature", "add two numbers")
+def test_add_two_numbers():
+    pass
+
+
+@given("two integers", target_fixture="numbers")
+def numbers():
+    return {"a": st.integers().example(), "b": st.integers().example()}
+
+
+@when("I add them")
+def add(numbers):
+    numbers["result"] = numbers["a"] + numbers["b"]
+
+
+@then("the result equals the sum")
+def check_sum(numbers):
+    assert numbers["result"] == numbers["a"] + numbers["b"]


### PR DESCRIPTION
## Summary
- add pytest-bdd and hypothesis to test dependencies
- show behaviour-driven test example in README
- provide `addition.feature` and test using Hypothesis for sample values

## Testing
- `nox -s lint`
- `nox -s tests`


------
https://chatgpt.com/codex/tasks/task_e_6858b35507fc8323920d459b53776774