### PR TITLE
Implement P0 runtime type checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,5 +92,8 @@ Run the suite with:
 just test
 ```
 
+Runtime type checks (Typeguard) run automatically.
+Disable locally: `pytest -q -p no:pytest_typeguard`
+
 Non-developers can introduce new behaviour by copying a feature file and writing
 English steps only.

--- a/noxfile.py
+++ b/noxfile.py
@@ -4,10 +4,10 @@ nox.options.sessions = ["tests", "lint"]
 nox.options.reuse_existing_virtualenvs = True
 
 
-@nox.session
+@nox.session(reuse_venv=True)
 def tests(session: nox.Session) -> None:
-    session.install(".[test]")
-    session.run("pytest", "-q", "--cov")
+    session.install("-e", ".[dev]")
+    session.run("pytest", "-q")
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,12 @@ test = [
 dev = [
     "ruff",
     "nox",
+    "pytest",
+    "pytest-bdd",
+    "hypothesis",
+    "pytest-cov",
+    "typeguard",
+    "pytest-typeguard",
 ]
 
 [tool.ruff]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = --typeguard-packages=econexyz
+


### PR DESCRIPTION
## Summary
- integrate typeguard test runner
- add pytest.ini with typeguard settings
- update README testing instructions
- install dev deps in tests session

## Testing
- `nox -s tests` *(fails: Could not find a version that satisfies the requirement pytest-typeguard)*

------
https://chatgpt.com/codex/tasks/task_e_6858c3fc364c8323ac346bc2ba1c8c7c