### PR TITLE
feat: integrate commitizen tooling

### DIFF
--- a/.cz.toml
+++ b/.cz.toml
@@ -1,0 +1,5 @@
+[tool.commitizen]
+name = "cz_conventional_commits"
+tag_format = "v$version"
+version_files = ["pyproject.toml"]
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,11 @@
 # Pre-commit configuration file
-# This file is intentionally empty to prevent pre-commit errors
-# Add hooks here as needed for your project
 
-repos: [] 
+repos:
+  - repo: local
+    hooks:
+      - id: cz-check
+        name: Commitizen check
+        entry: cz check
+        language: system
+        stages: [commit-msg]
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+# Changelog
+

--- a/Justfile
+++ b/Justfile
@@ -47,6 +47,14 @@ image tag="latest":
 run *ARGS:
     @echo "run {{ARGS}} \u2192 TODO (will call python -m yourpackage.cli)"
 
+# Commit helper
+commit:
+    cz commit            # interactive wizard
+
+# Version bump
+bump:
+    cz bump --yes        # version & changelog
+
 # Agent scaffolding
 # Scaffold a new agent
 new-agent name slug:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ just test    # Run the test suite with coverage
 just lint    # Check code style with ruff
 ```
 
+### Commit workflow
+
+```bash
+git add .
+just commit        # interactive wizard
+```
+
+Direct `git commit -m` is allowed but must follow Conventional Commit rules.
+
 ## Quality gates
 
 | Command | Purpose |

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -72,6 +72,10 @@ elif [ -f pyproject.toml ]; then
   uv pip install -e .[dev,test]
 fi
 
+# Install Commitizen for commit management
+  uv tool install commitizen
+  uv tool upgrade commitizen || true
+
 # Optionally install pre-commit hooks
 if [ -z "$install_hooks" ]; then
   read -r -p "Install git pre-commit hooks? [y/N] " reply


### PR DESCRIPTION
## Summary
- install Commitizen and add config
- wire Commitizen check in pre-commit
- expose `commit` and `bump` tasks
- document the Commit workflow
- add placeholder `CHANGELOG.md`

## Testing
- `nox -s tests` *(fails: TypeCheckError)*

------
https://chatgpt.com/codex/tasks/task_e_6858ccf706ac8323b2ba4f1775882cc8