### PR TITLE
feat: add commitlint checks

### DIFF
--- a/.commitlintrc.cjs
+++ b/.commitlintrc.cjs
@@ -1,0 +1,12 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'header-max-length': [2, 'always', 52],
+    'subject-case': [
+      2,
+      'never',
+      ['sentence-case', 'start-case', 'pascal-case', 'upper-case'],
+    ],
+    'subject-full-stop': [2, 'never', '.'],
+  },
+};

--- a/.github/workflows/commit-style.yml
+++ b/.github/workflows/commit-style.yml
@@ -1,0 +1,24 @@
+name: Commit style
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install commitizen
+        run: pip install commitizen
+      - name: Commitizen check
+        run: |
+          cz check --rev-range ${{ github.event.pull_request.base.sha }}..${{ github.sha }}
+      - name: Commitlint (header ≤52 chars etc.)
+        uses: wagoid/commitlint-github-action@v5
+        with:
+          configFile: .commitlintrc.cjs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,4 +8,9 @@ repos:
         entry: cz check
         language: system
         stages: [commit-msg]
+      - id: commitlint
+        name: Commitlint 52-char header
+        entry: npx --yes commitlint --edit $1
+        language: system
+        stages: [commit-msg]
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ just commit        # interactive wizard
 ```
 
 Direct `git commit -m` is allowed but must follow Conventional Commit rules.
+Headers must stay ≤ 52 characters; CI will block longer ones.
 
 ## Quality gates
 

--- a/scripts/dev_health_check.py
+++ b/scripts/dev_health_check.py
@@ -23,10 +23,11 @@ def check_dev_dependencies():
 
         # Get dev dependencies
         dev_deps = data["project"]["optional-dependencies"]["dev"]
-        
+
         # Map package names to import names for special cases
         # Some packages (like pytest-bdd and pytest-cov) have different import names than their PyPI names.
-        # If you add a new dev dependency and the health check fails, check if the import name differs from the package name and add it here.
+        # If you add a new dev dependency and the health check fails,
+        # check if the import name differs from the package name and add it here.
         import_name_map = {
             "pytest-bdd": "pytest_bdd",
             "pytest-cov": "pytest_cov",
@@ -38,7 +39,7 @@ def check_dev_dependencies():
             # Handle package names with extras like "pytest-bdd"
             package_name = dep.split("[")[0] if "[" in dep else dep
             import_name = import_name_map.get(package_name, package_name)
-            
+
             try:
                 __import__(import_name)
             except ImportError:
@@ -48,7 +49,7 @@ def check_dev_dependencies():
             print(f"❌ Missing dev dependencies: {', '.join(missing_deps)}")
             print("💡 Run ./bootstrap.sh to install missing dependencies")
             return False
-        
+
         print("✅ All dev dependencies available")
         return True
 
@@ -59,4 +60,4 @@ def check_dev_dependencies():
 
 if __name__ == "__main__":
     success = check_dev_dependencies()
-    sys.exit(0 if success else 1) 
+    sys.exit(0 if success else 1)

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -2,6 +2,7 @@
 
 import pytest
 from typeguard import TypeCheckError
+
 from econexyz import add_numbers
 
 
@@ -16,4 +17,4 @@ def test_typeguard_catches_type_errors():
     """Test that typeguard catches type errors at runtime."""
     # This should trigger a typeguard error if typeguard is working
     with pytest.raises(TypeCheckError):
-        add_numbers("5", 3)  # type: ignore # Wrong type for first argument 
+        add_numbers("5", 3)  # type: ignore # Wrong type for first argument


### PR DESCRIPTION
## Summary
- add commitlint configuration
- run commitlint & commitizen in a new commit-style workflow
- enforce commitlint locally via pre-commit hook
- mention 52-char header limit in README
- fix lint issues

## Testing
- `nox -s lint`
- `nox -s tests`
- `nox -s types`


------
https://chatgpt.com/codex/tasks/task_e_6858d2942728832391e37beec43c1967