### PR TITLE
feat: introduce architecture decision records

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,16 @@ Additional recipes are available for development, documentation, and deployment 
 
 Coverage threshold: **≥ 80 %** (`nox -s tests` generates htmlcov/)
 
+## Project conventions
+
+Architecture Decision Records live under [`docs/adr/`](docs/adr/index.md).
+They capture the context and consequences of major engineering choices.
+Create a new entry with:
+
+```bash
+adr-new "Use Read the Docs for hosting"
+```
+
 ## How to contribute
 
 We welcome contributions from everyone. Please read

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,4 +1,4 @@
-# 0001 – ADR Process
+# 0001 – Record Architecture Decisions
 
 *Status*: **Accepted**
 

--- a/docs/adr/0042-docs-hosting.md
+++ b/docs/adr/0042-docs-hosting.md
@@ -1,0 +1,16 @@
+# 0042 – Docs Hosting Strategy
+
+*Status*: **Accepted**
+
+## Context
+
+We need a reliable place to publish documentation without maintaining custom infrastructure. Read the Docs offers automated builds and search while allowing easy migration to GitHub Pages if needed.
+
+## Decision
+
+Host `econexyz` documentation on **Read the Docs** for now. A simple GitHub Pages workflow will remain as a fallback should Read the Docs become unsuitable.
+
+## Consequences
+
+* Minimal setup; docs build on every push.
+* If Read the Docs limits or tooling changes, we can switch to Pages with little effort.

--- a/docs/adr/adr.log.md
+++ b/docs/adr/adr.log.md
@@ -1,5 +1,5 @@
 Below are **ADR 0001 → ADR 0010** rewritten with fuller context, decisions, alternatives, and consequences.
-Feel free to copy each into its own file (e.g., `docs/adr/0001-adr-process.md`, …).
+Feel free to copy each into its own file (e.g., `docs/adr/0001-record-architecture-decisions.md`, …).
 
 ---
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -1,6 +1,7 @@
 # Architecture Decision Records
 
-- [0001: ADR Process](0001-adr-process.md)
+- [0001: Record Architecture Decisions](0001-record-architecture-decisions.md)
+- [0002: Docs Hosting Strategy](0002-docs-hosting.md)
 - [0002: Bootstrap `sh` + `uv`](0002-bootstrap-sh-uv.md)
 - [0003: Optional Pre-commit Install](0003-optional-precommit-install.md)
 - [0004: Justfile Core Recipes](0004-justfile-core-recipes.md)
@@ -41,3 +42,4 @@
 - [0039: JSON-Schema Contract Tests](0039-jsonschema-contract-tests.md)
 - [0040: Hypothesis GraphQL Fuzz](0040-hypothesis-graphql-fuzz.md)
 - [0041: Single-Schema Bridge (Pydantic ↔ Strawberry)](0041-single-schema-bridge.md)
+- [0042: Docs Hosting Strategy](0042-docs-hosting.md)

--- a/scripts/adr-new
+++ b/scripts/adr-new
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Create a new ADR from template with incremented number
+set -euo pipefail
+
+adr_dir="docs/adr"
+last_num=$(ls "$adr_dir" | grep -E '^[0-9]{4}-.+\.md$' | sort | tail -n 1 | cut -d'-' -f1)
+next_num=$(printf "%04d" $((10#$last_num + 1)))
+slug="$(echo "$*" | tr 'A-Z ' 'a-z-' | tr -cd 'a-z0-9-')"
+file="$adr_dir/${next_num}-${slug}.md"
+
+sed "s/{ADR-ID}/${next_num}/" "$adr_dir/_template.md" > "$file"
+
+echo "Created $file"


### PR DESCRIPTION
## Summary
- add ADR helper script
- rename first ADR to `0001-record-architecture-decisions`
- document ADR usage in README
- record docs hosting decision in ADR 0042

## Testing
- `uv pip install --system -e .[dev]`
- `python -m nox -s tests`
- `ruff check .`
- `ruff format --check .`


------
https://chatgpt.com/codex/tasks/task_e_685ac317e0a08323985c2a4a6e0f9a65