### PR TITLE
Implement coverage comment groundwork (P0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ just commit        # interactive wizard
 Direct `git commit -m` is allowed but must follow Conventional Commit rules.
 Headers must stay ≤ 52 characters; CI will block longer ones.
 
-## Quality gates
+## Quality & Security
+
+![coverage](https://raw.githubusercontent.com/<org>/<repo>/gh-pages-coverage/coverage.svg)
 
 | Command | Purpose |
 | ------- | ------- |

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,6 +13,7 @@ def tests(session: nox.Session) -> None:
         "--cov=econexyz",
         "--cov-report=xml",
         "--cov-report=html",
+        "--cov-report=term",
         "--cov-fail-under=80",
         external=True,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,14 @@ dev = [
     "ty",
     "commitizen"
 ]
+test = [
+    "pytest",
+    "pytest-bdd",
+    "hypothesis",
+    "pytest-cov",
+    "schemathesis",
+    "coverage"
+]
 
 [dependency-groups]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -291,6 +291,14 @@ dev = [
     { name = "ty" },
     { name = "typeguard" },
 ]
+test = [
+    { name = "coverage" },
+    { name = "hypothesis" },
+    { name = "pytest" },
+    { name = "pytest-bdd" },
+    { name = "pytest-cov" },
+    { name = "schemathesis" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -316,18 +324,24 @@ requires-dist = [
     { name = "codecov", marker = "extra == 'dev'" },
     { name = "commitizen", marker = "extra == 'dev'" },
     { name = "coverage", marker = "extra == 'dev'" },
+    { name = "coverage", marker = "extra == 'test'" },
     { name = "hypothesis", marker = "extra == 'dev'" },
+    { name = "hypothesis", marker = "extra == 'test'" },
     { name = "nox", marker = "extra == 'dev'" },
     { name = "nox-uv", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'test'" },
     { name = "pytest-bdd", marker = "extra == 'dev'" },
+    { name = "pytest-bdd", marker = "extra == 'test'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
+    { name = "pytest-cov", marker = "extra == 'test'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "schemathesis", marker = "extra == 'dev'" },
+    { name = "schemathesis", marker = "extra == 'test'" },
     { name = "ty", marker = "extra == 'dev'" },
     { name = "typeguard", marker = "extra == 'dev'" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["dev", "test"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- add placeholder coverage badge to README
- expose test extras with coverage tools
- surface coverage details in Nox output
- track extras in lockfile

## Testing
- `./bootstrap.sh --no-hooks nox -s tests`
- `just check`


------
https://chatgpt.com/codex/tasks/task_e_685b22951bb883239d99a6a5c78a8f4b