### PR TITLE
Implement docs publishing

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,20 @@
+name: docs
+
+on:
+  push:
+    branches: [main]
+  push:
+    tags: ['*']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./bootstrap.sh
+      - run: nox -s docs
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          publish_dir: docs/_build/html
+          publish_branch: gh-pages
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # 🦾 EcoNexyz: Agent Development Guide (`AGENTS.md`)
 [![build / Hello World](https://github.com/plva/econexyz/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/plva/econexyz/actions/workflows/ci.yml)
+[![docs](https://img.shields.io/badge/docs-live-blue)](https://plva.github.io/econexyz/)
 
 Use GitHub issues for instructions. If you have an issue number, fetch its body with:
 


### PR DESCRIPTION
## Summary
- deploy docs automatically on push and tag via GitHub Pages
- show docs badge in README

## Testing
- `./bootstrap.sh --no-hooks just check`

------
https://chatgpt.com/codex/tasks/task_e_685b7bca3968832383b7d6b43709f38a