### PR TITLE
feat(ci): add coverage badge workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,7 +17,6 @@ jobs:
       - name: Python Coverage Comment
         uses: py-cov-action/python-coverage-comment-action@v3
         with:
-          badge-title: coverage
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERAGE_DATA_BRANCH: gh-pages-coverage
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,23 @@
+name: coverage
+
+on:
+  pull_request: {}
+  push:
+    branches: [ main ]
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: ./bootstrap.sh nox -s tests
+      - name: Python Coverage Comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          badge-title: coverage
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          COVERAGE_DATA_BRANCH: gh-pages-coverage
+

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Direct `git commit -m` is allowed but must follow Conventional Commit rules.
 Headers must stay ≤ 52 characters; CI will block longer ones.
 
 ## Quality & Security
-![coverage](https://raw.githubusercontent.com/<org>/<repo>/gh-pages-coverage/coverage.svg)
+![coverage](https://raw.githubusercontent.com/plva/econexyz/gh-pages-coverage/coverage.svg)
 
 | Command | Purpose |
 | ------- | ------- |

--- a/docs/github-branch-protection.md
+++ b/docs/github-branch-protection.md
@@ -10,6 +10,7 @@ After setting up the workflows in this repository, GitHub will emit these status
 - **tests** - Runs pytest with coverage on Python 3.12
 
 ### Optional Checks
+- **coverage** - Publishes coverage badge (.github/workflows/coverage.yml); mark required once stable
 - **commit-style** - Validates commit message format (from `.github/workflows/commit-style.yml`)
 
 ## Setting Up Branch Protection Rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ docs = [
 [tool.coverage.run]
 branch = true
 source = ["econexyz"]
+relative_files = true
 
 [tool.coverage.report]
 exclude_lines = [


### PR DESCRIPTION
## Summary
- publish coverage results with a GitHub Action
- display coverage badge in the README
- document coverage check in branch protection guide

## Testing
- `just check`

------
https://chatgpt.com/codex/tasks/task_e_685b81cc26c48323a6f97f925ed931c3