### PR TITLE
Add label sync workflow and discussion badge

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,19 @@
+labels:
+  - name: bug
+    color: d73a4a
+    description: Bug report
+  - name: feature
+    color: a2eeef
+    description: New feature or enhancement
+  - name: question
+    color: d876e3
+    description: Further clarification needed
+  - name: risk:high
+    color: b60205
+    description: High risk changes
+  - name: risk:medium
+    color: fbca04
+    description: Medium risk changes
+  - name: risk:low
+    color: 0e8a16
+    description: Low risk changes

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,17 @@
+name: labels
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: crazy-max/ghaction-github-labeler@v5
+        with:
+          yaml_file: .github/labels.yml
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # 🦾 EcoNexyz: Agent Development Guide (`AGENTS.md`)
 [![build / Hello World](https://github.com/plva/econexyz/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/plva/econexyz/actions/workflows/ci.yml)
 [![docs](https://img.shields.io/badge/docs-live-blue)](https://plva.github.io/econexyz/)
+[![Need help? Ask here](https://img.shields.io/badge/discussions-ask%20here-brightgreen)](https://github.com/plva/econexyz/discussions)
 
 Use GitHub issues for instructions. If you have an issue number, fetch its body with:
 


### PR DESCRIPTION
## Summary
- sync labels via GitHub Labeler
- add risk/type labels configuration
- link to GitHub Discussions with a README badge

## Testing
- `./bootstrap.sh --no-hooks just lint`
- `./bootstrap.sh --no-hooks just test`
- `./bootstrap.sh --no-hooks just types`


------
https://chatgpt.com/codex/tasks/task_e_685b837331c483238548b3d1361ddafa