### PR TITLE
fix: resolve duplicate push keys in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,6 @@ name: docs
 on:
   push:
     branches: [main]
-  push:
     tags: ['*']
 
 jobs:


### PR DESCRIPTION
## Checklist

- [ x] Follows Conventional Commits
- [ x] `just lint && just test` pass locally
- [ x] Docs/CHANGELOG updated if needed
- [x ] This change follows the Code → Surface → Govern cadence (see ADR 0043)

Please link any related issues and apply appropriate labels.

